### PR TITLE
Add Prisma seeding script

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,0 +1,81 @@
+import { PrismaClient } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+const saltRounds = 10;
+
+async function main() {
+  const managerRole = await prisma.role.upsert({
+    where: { id: 1 },
+    update: {},
+    create: {
+      id: 1,
+      name: 'manager',
+    },
+  });
+
+  await prisma.role.upsert({
+    where: { id: 2 },
+    update: {},
+    create: {
+      id: 2,
+      name: 'staff',
+    },
+  });
+
+  const permissionCodes = [
+    'view_logs',
+    'import_data',
+    'export_data',
+    'delete_flavor',
+    'manage_users',
+  ];
+
+  const permissions = [] as { id: number }[];
+  for (const code of permissionCodes) {
+    const perm = await prisma.permission.upsert({
+      where: { code },
+      update: { description: code },
+      create: { code, description: code },
+    });
+    permissions.push({ id: perm.id });
+  }
+
+  for (const perm of permissions) {
+    await prisma.rolePermission.upsert({
+      where: { id: perm.id },
+      update: {},
+      create: { id: perm.id, roleId: managerRole.id, permissionId: perm.id },
+    });
+  }
+
+  const passwordHash = bcrypt.hashSync('123456', saltRounds);
+
+  await prisma.user.upsert({
+    where: { username: 'admin' },
+    update: {
+      firstName: 'Admin',
+      lastName: 'User',
+      roleId: managerRole.id,
+      passwordHash,
+    },
+    create: {
+      firstName: 'Admin',
+      lastName: 'User',
+      username: 'admin',
+      passwordHash,
+      roleId: managerRole.id,
+    },
+  });
+
+  console.log('Seed complete');
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- seed initial roles, permissions, and admin user with bcrypt password

## Testing
- `npx -y tsx prisma/seed.ts` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_687a0f20bde48332acfc40ec10e4ddf6