### PR TITLE
Add import/export jobs

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,10 @@
     "class-validator": "^0.14.2",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^5.0.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "multer": "^1.4.5-lts.1",
+    "csv-parse": "^5.5.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   roleId       Int
   permissions  UserPermission[]
   auditLogs    AuditLog[]
+  importJobs   ImportJob[]
 }
 
 model Role {
@@ -63,6 +64,7 @@ model Flavor {
   name        String
   description String?
   profile     String?
+  stocks      Stock[]
 }
 
 model AuditLog {
@@ -74,4 +76,22 @@ model AuditLog {
   userId    Int
   timestamp DateTime @default(now())
   details   Json
+}
+
+model Stock {
+  id        Int    @id @default(autoincrement())
+  flavor    Flavor @relation(fields: [flavorId], references: [id])
+  flavorId  Int
+  quantity  Int
+}
+
+model ImportJob {
+  id           Int      @id @default(autoincrement())
+  entityType   String
+  filename     String
+  uploadedBy   User     @relation(fields: [uploadedById], references: [id])
+  uploadedById Int
+  status       String   @default("pending")
+  errors       Json?
+  createdAt    DateTime @default(now())
 }

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -1,0 +1,59 @@
+import { BadRequestException, Body, Controller, Get, Param, ParseIntPipe, Post, Req, Res, UploadedFile, UseGuards, UseInterceptors } from '@nestjs/common';
+import { Express } from 'express';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { ImportService } from './import.service';
+import { ExportService } from './export.service';
+import { AuthGuard } from '../auth/auth.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permission } from '../auth/permission.decorator';
+
+@Controller()
+export class AdminController {
+  constructor(
+    private importService: ImportService,
+    private exportService: ExportService,
+  ) {}
+
+  @Post('admin/import')
+  @UseGuards(AuthGuard, PermissionsGuard)
+  @Permission('import_data')
+  @UseInterceptors(FileInterceptor('file'))
+  async import(
+    @UploadedFile() file: Express.Multer.File,
+    @Body('entityType') entityType: string,
+    @Req() req,
+  ) {
+    if (!file) throw new BadRequestException('File required');
+    if (!['flavors', 'stocks'].includes(entityType)) {
+      throw new BadRequestException('Invalid entityType');
+    }
+    return this.importService.createJob(file, entityType, req.user.id);
+  }
+
+  @Get('admin/import/:id')
+  @UseGuards(AuthGuard, PermissionsGuard)
+  @Permission('import_data')
+  getJob(@Param('id', ParseIntPipe) id: number) {
+    return this.importService.getJob(id);
+  }
+
+  @Get('export/flavors.xlsx')
+  @UseGuards(AuthGuard, PermissionsGuard)
+  @Permission('export_data')
+  async exportFlavors(@Res() res) {
+    const buffer = await this.exportService.flavorsXlsx();
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', 'attachment; filename="flavors.xlsx"');
+    res.send(buffer);
+  }
+
+  @Get('export/stocks.csv')
+  @UseGuards(AuthGuard, PermissionsGuard)
+  @Permission('export_data')
+  async exportStocks(@Res() res) {
+    const csv = await this.exportService.stocksCsv();
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader('Content-Disposition', 'attachment; filename="stocks.csv"');
+    res.send(csv);
+  }
+}

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { MulterModule } from '@nestjs/platform-express';
+import { AdminController } from './admin.controller';
+import { ImportService } from './import.service';
+import { ExportService } from './export.service';
+import { PrismaService } from '../prisma.service';
+import { AuditService } from '../audit/audit.service';
+
+@Module({
+  imports: [MulterModule.register({ dest: 'uploads' })],
+  controllers: [AdminController],
+  providers: [ImportService, ExportService, PrismaService, AuditService],
+})
+export class AdminModule {}

--- a/backend/src/admin/export.service.ts
+++ b/backend/src/admin/export.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import * as xlsx from 'xlsx';
+
+@Injectable()
+export class ExportService {
+  constructor(private prisma: PrismaService) {}
+
+  async flavorsXlsx(): Promise<Buffer> {
+    const flavors = await this.prisma.flavor.findMany();
+    const data = flavors.map(f => ({
+      id: f.id,
+      brandId: f.brandId,
+      name: f.name,
+      description: f.description ?? '',
+      profile: f.profile ?? '',
+    }));
+    const ws = xlsx.utils.json_to_sheet(data);
+    const wb = xlsx.utils.book_new();
+    xlsx.utils.book_append_sheet(wb, ws, 'Flavors');
+    return xlsx.write(wb, { type: 'buffer', bookType: 'xlsx' });
+  }
+
+  async stocksCsv(): Promise<string> {
+    const stocks = await this.prisma.stock.findMany();
+    const header = 'id,flavorId,quantity';
+    const lines = stocks.map(s => `${s.id},${s.flavorId},${s.quantity}`);
+    return [header, ...lines].join('\n');
+  }
+}

--- a/backend/src/admin/import.service.ts
+++ b/backend/src/admin/import.service.ts
@@ -1,0 +1,91 @@
+import { Injectable } from '@nestjs/common';
+import { ImportJob } from '@prisma/client';
+import { PrismaService } from '../prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { Express } from 'express';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { parse } from 'csv-parse/sync';
+import * as xlsx from 'xlsx';
+
+@Injectable()
+export class ImportService {
+  constructor(private prisma: PrismaService, private audit: AuditService) {
+    setInterval(() => this.processPendingJobs(), 15000);
+  }
+
+  async createJob(file: Express.Multer.File, entityType: string, userId: number) {
+    const filename = `${Date.now()}_${file.originalname}`;
+    await fs.mkdir('uploads', { recursive: true });
+    await fs.writeFile(path.join('uploads', filename), file.buffer);
+    return this.prisma.importJob.create({
+      data: { entityType, filename, uploadedById: userId, status: 'pending' },
+    });
+  }
+
+  getJob(id: number) {
+    return this.prisma.importJob.findUnique({ where: { id } });
+  }
+
+  private async processPendingJobs() {
+    const jobs = await this.prisma.importJob.findMany({ where: { status: 'pending' } });
+    for (const job of jobs) {
+      const errors = await this.handleJob(job).catch(e => [e.message]);
+      await this.prisma.importJob.update({
+        where: { id: job.id },
+        data: { status: errors.length ? 'failed' : 'completed', errors },
+      });
+    }
+  }
+
+  private async handleJob(job: ImportJob): Promise<string[]> {
+    const filePath = path.join('uploads', job.filename);
+    let rows: any[] = [];
+    if (filePath.endsWith('.csv')) {
+      const content = await fs.readFile(filePath, 'utf8');
+      rows = parse(content, { columns: true, skip_empty_lines: true });
+    } else {
+      const wb = xlsx.readFile(filePath);
+      rows = xlsx.utils.sheet_to_json(wb.Sheets[wb.SheetNames[0]]);
+    }
+    const errors: string[] = [];
+    if (job.entityType === 'flavors') {
+      for (const r of rows) {
+        try {
+          const data = {
+            brandId: Number(r.brandId),
+            name: String(r.name),
+            description: r.description || undefined,
+            profile: r.profile || undefined,
+          };
+          await this.prisma.flavor.upsert({
+            where: { id: Number(r.id) || 0 },
+            update: data,
+            create: { id: r.id ? Number(r.id) : undefined, ...data },
+          });
+          await this.audit.log('Flavor', Number(r.id), 'CREATE', job.uploadedById, data);
+        } catch (e) {
+          errors.push(`Row ${JSON.stringify(r)}: ${e.message}`);
+        }
+      }
+    } else if (job.entityType === 'stocks') {
+      for (const r of rows) {
+        try {
+          const data = {
+            flavorId: Number(r.flavorId),
+            quantity: Number(r.quantity),
+          };
+          await this.prisma.stock.upsert({
+            where: { id: Number(r.id) || 0 },
+            update: data,
+            create: { id: r.id ? Number(r.id) : undefined, ...data },
+          });
+          await this.audit.log('Stock', Number(r.id), 'CREATE', job.uploadedById, data);
+        } catch (e) {
+          errors.push(`Row ${JSON.stringify(r)}: ${e.message}`);
+        }
+      }
+    }
+    return errors;
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from './auth/auth.module';
 import { BrandsModule } from './brands/brands.module';
 import { FlavorsModule } from './flavors/flavors.module';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
-  imports: [AuthModule, BrandsModule, FlavorsModule],
+  imports: [AuthModule, BrandsModule, FlavorsModule, AdminModule],
   providers: [],
 })
 export class AppModule {}


### PR DESCRIPTION
## Summary
- add Stock and ImportJob models to Prisma schema
- create Admin module with import/export endpoints
- support CSV/XLSX file import with background worker
- enable export endpoints for flavors and stocks

## Testing
- `npx prisma generate`
- `npm install`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_687a4ffa3a108332adc249673259e1c2