### PR TITLE
Add Stock service and controller

### DIFF
--- a/backend/src/stocks/dto/create-stock.dto.ts
+++ b/backend/src/stocks/dto/create-stock.dto.ts
@@ -1,0 +1,9 @@
+import { IsInt } from 'class-validator';
+
+export class CreateStockDto {
+  @IsInt()
+  flavorId: number;
+
+  @IsInt()
+  quantity: number;
+}

--- a/backend/src/stocks/dto/update-stock.dto.ts
+++ b/backend/src/stocks/dto/update-stock.dto.ts
@@ -1,0 +1,11 @@
+import { IsInt, IsOptional } from 'class-validator';
+
+export class UpdateStockDto {
+  @IsInt()
+  @IsOptional()
+  flavorId?: number;
+
+  @IsInt()
+  @IsOptional()
+  quantity?: number;
+}

--- a/backend/src/stocks/stock.controller.ts
+++ b/backend/src/stocks/stock.controller.ts
@@ -1,0 +1,54 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { StockService } from './stock.service';
+import { CreateStockDto } from './dto/create-stock.dto';
+import { UpdateStockDto } from './dto/update-stock.dto';
+import { AuthGuard } from '../auth/auth.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permission } from '../auth/permission.decorator';
+import { User } from '../auth/user.decorator';
+
+@Controller('stocks')
+export class StockController {
+  constructor(private stocks: StockService) {}
+
+  @Get()
+  list() {
+    return this.stocks.list();
+  }
+
+  @Post()
+  @UseGuards(AuthGuard, PermissionsGuard)
+  @Permission('import_data')
+  create(@Body() dto: CreateStockDto, @User() user) {
+    return this.stocks.create(dto, user.id);
+  }
+
+  @Put(':id')
+  @UseGuards(AuthGuard, PermissionsGuard)
+  @Permission('import_data')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateStockDto,
+    @User() user,
+  ) {
+    return this.stocks.update(id, dto, user.id);
+  }
+
+  @Delete(':id')
+  @UseGuards(AuthGuard, PermissionsGuard)
+  @Permission('delete_flavor')
+  async delete(@Param('id', ParseIntPipe) id: number, @User() user) {
+    await this.stocks.remove(id, user.id);
+    return { success: true };
+  }
+}

--- a/backend/src/stocks/stock.service.ts
+++ b/backend/src/stocks/stock.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { CreateStockDto } from './dto/create-stock.dto';
+import { UpdateStockDto } from './dto/update-stock.dto';
+
+@Injectable()
+export class StockService {
+  constructor(private prisma: PrismaService, private audit: AuditService) {}
+
+  list() {
+    return this.prisma.stock.findMany({
+      include: { flavor: { select: { name: true } } },
+    });
+  }
+
+  async create(dto: CreateStockDto, userId: number) {
+    const stock = await this.prisma.stock.create({ data: dto });
+    await this.audit.log('Stock', stock.id, 'CREATE', userId, dto);
+    return stock;
+  }
+
+  async update(id: number, dto: UpdateStockDto, userId: number) {
+    const stock = await this.prisma.stock.update({ where: { id }, data: dto });
+    const diff = Object.fromEntries(
+      Object.entries(dto).filter(([, v]) => v !== undefined),
+    );
+    await this.audit.log('Stock', id, 'UPDATE', userId, diff);
+    return stock;
+  }
+
+  async remove(id: number, userId: number) {
+    await this.prisma.stock.delete({ where: { id } });
+    await this.audit.log('Stock', id, 'DELETE', userId, {});
+  }
+}


### PR DESCRIPTION
## Summary
- add CRUD endpoints for Stocks with guard-based permissions
- implement Stock service with audit logging
- add Create/Update Stock DTOs

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_687a60bd0e388332ba09546fab4be1e4