### PR TITLE
Add audit log listing

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { FlavorsModule } from './flavors/flavors.module';
 import { AdminModule } from './admin/admin.module';
 import { StockModule } from './stocks/stock.module';
 import { UsersModule } from './users/users.module';
+import { AuditModule } from './audit/audit.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { UsersModule } from './users/users.module';
     AdminModule,
     StockModule,
     UsersModule,
+    AuditModule,
   ],
   providers: [],
 })

--- a/backend/src/audit/audit.controller.ts
+++ b/backend/src/audit/audit.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Query, ParseIntPipe, UseGuards } from '@nestjs/common';
+import { AuditService } from './audit.service';
+import { AuthGuard } from '../auth/auth.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permission } from '../auth/permission.decorator';
+
+@Controller('audit')
+@UseGuards(AuthGuard, PermissionsGuard)
+export class AuditController {
+  constructor(private audit: AuditService) {}
+
+  @Get()
+  @Permission('view_logs')
+  list(
+    @Query('model') model?: string,
+    @Query('action') action?: string,
+    @Query('userId', ParseIntPipe) userId?: number,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ) {
+    return this.audit.list({
+      model,
+      action,
+      userId: userId ? Number(userId) : undefined,
+      from: from ? new Date(from) : undefined,
+      to: to ? new Date(to) : undefined,
+    });
+  }
+}

--- a/backend/src/audit/audit.module.ts
+++ b/backend/src/audit/audit.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AuditController } from './audit.controller';
+import { AuditService } from './audit.service';
+import { PrismaService } from '../prisma.service';
+
+@Module({
+  controllers: [AuditController],
+  providers: [AuditService, PrismaService],
+})
+export class AuditModule {}

--- a/backend/src/audit/audit.service.ts
+++ b/backend/src/audit/audit.service.ts
@@ -16,4 +16,36 @@ export class AuditService {
       },
     });
   }
+
+  async list(filters: {
+    model?: string;
+    action?: string;
+    userId?: number;
+    from?: Date;
+    to?: Date;
+  }) {
+    const where: any = {};
+    if (filters.model) where.entity = filters.model;
+    if (filters.action) where.action = filters.action;
+    if (filters.userId) where.userId = filters.userId;
+    if (filters.from || filters.to) {
+      where.timestamp = {};
+      if (filters.from) where.timestamp.gte = filters.from;
+      if (filters.to) where.timestamp.lte = filters.to;
+    }
+    const logs = await this.prisma.auditLog.findMany({
+      where,
+      orderBy: { id: 'desc' },
+      include: { user: { select: { id: true, firstName: true, lastName: true } } },
+    });
+    return logs.map(l => ({
+      id: l.id,
+      model: l.entity,
+      modelId: l.entityId,
+      action: l.action,
+      diff: l.details,
+      createdAt: l.timestamp,
+      user: { id: l.user.id, fullName: `${l.user.firstName} ${l.user.lastName}` },
+    }));
+  }
 }


### PR DESCRIPTION
## Summary
- expose audit logs via new AuditModule
- implement controller for `GET /audit`
- query logs with optional filters and user info
- register module in AppModule

## Testing
- `npx tsc -p backend/tsconfig.json`
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a81500270833298ce1a11c73d55e7