### PR TITLE
Add Roles module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { AdminModule } from './admin/admin.module';
 import { StockModule } from './stocks/stock.module';
 import { UsersModule } from './users/users.module';
 import { AuditModule } from './audit/audit.module';
+import { RolesModule } from './roles/roles.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { AuditModule } from './audit/audit.module';
     AdminModule,
     StockModule,
     UsersModule,
+    RolesModule,
     AuditModule,
   ],
   providers: [],

--- a/backend/src/roles/dto/create-role.dto.ts
+++ b/backend/src/roles/dto/create-role.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateRoleDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+}

--- a/backend/src/roles/dto/update-permissions.dto.ts
+++ b/backend/src/roles/dto/update-permissions.dto.ts
@@ -1,0 +1,8 @@
+import { ArrayUnique, IsArray, IsString } from 'class-validator';
+
+export class UpdatePermissionsDto {
+  @IsArray()
+  @ArrayUnique()
+  @IsString({ each: true })
+  permissions: string[];
+}

--- a/backend/src/roles/roles.controller.ts
+++ b/backend/src/roles/roles.controller.ts
@@ -1,0 +1,44 @@
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, UseGuards } from '@nestjs/common';
+import { RolesService } from './roles.service';
+import { CreateRoleDto } from './dto/create-role.dto';
+import { UpdatePermissionsDto } from './dto/update-permissions.dto';
+import { AuthGuard } from '../auth/auth.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permission } from '../auth/permission.decorator';
+import { User } from '../auth/user.decorator';
+
+@Controller('roles')
+export class RolesController {
+  constructor(private roles: RolesService) {}
+
+  @Get()
+  list() {
+    return this.roles.list();
+  }
+
+  @Post()
+  @UseGuards(AuthGuard, PermissionsGuard)
+  @Permission('manage_roles')
+  create(@Body() dto: CreateRoleDto, @User() user) {
+    return this.roles.create(dto, user.id);
+  }
+
+  @Delete(':id')
+  @UseGuards(AuthGuard, PermissionsGuard)
+  @Permission('manage_roles')
+  async delete(@Param('id', ParseIntPipe) id: number, @User() user) {
+    await this.roles.remove(id, user.id);
+    return { success: true };
+  }
+
+  @Put(':id/permissions')
+  @UseGuards(AuthGuard, PermissionsGuard)
+  @Permission('manage_roles')
+  updatePermissions(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdatePermissionsDto,
+    @User() user,
+  ) {
+    return this.roles.updatePermissions(id, dto.permissions, user.id);
+  }
+}

--- a/backend/src/roles/roles.module.ts
+++ b/backend/src/roles/roles.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { RolesController } from './roles.controller';
+import { RolesService } from './roles.service';
+import { PrismaService } from '../prisma.service';
+import { AuditService } from '../audit/audit.service';
+
+@Module({
+  controllers: [RolesController],
+  providers: [RolesService, PrismaService, AuditService],
+})
+export class RolesModule {}

--- a/backend/src/roles/roles.service.ts
+++ b/backend/src/roles/roles.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { CreateRoleDto } from './dto/create-role.dto';
+
+@Injectable()
+export class RolesService {
+  constructor(private prisma: PrismaService, private audit: AuditService) {}
+
+  async list() {
+    const roles = await this.prisma.role.findMany({
+      include: { permissions: { include: { permission: true } } },
+    });
+    return roles.map(r => ({
+      id: r.id,
+      name: r.name,
+      permissions: r.permissions.map(rp => rp.permission),
+    }));
+  }
+
+  async create(dto: CreateRoleDto, userId: number) {
+    const role = await this.prisma.role.create({ data: { name: dto.name } });
+    await this.audit.log('Role', role.id, 'CREATE', userId, { name: dto.name });
+    return role;
+  }
+
+  async remove(id: number, userId: number) {
+    await this.prisma.role.delete({ where: { id } });
+    await this.audit.log('Role', id, 'DELETE', userId, {});
+  }
+
+  async updatePermissions(roleId: number, codes: string[], userId: number) {
+    const permissions = await this.prisma.permission.findMany({
+      where: { code: { in: codes } },
+      select: { id: true },
+    });
+
+    await this.prisma.rolePermission.deleteMany({ where: { roleId } });
+    if (permissions.length > 0) {
+      await this.prisma.rolePermission.createMany({
+        data: permissions.map(p => ({ roleId, permissionId: p.id })),
+      });
+    }
+
+    await this.audit.log('Role', roleId, 'UPDATE', userId, { permissions: codes });
+    return this.prisma.role.findUnique({
+      where: { id: roleId },
+      include: { permissions: { include: { permission: true } } },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a Roles module with CRUD endpoints for roles and permissions
- create DTOs for role creation and permission updates
- wire up Prisma-powered service with audit logging
- register RolesModule in the AppModule

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687a82ed10e48332b0bf5e9471666cdf