### PR TITLE
Add Requests module

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   permissions  UserPermission[]
   auditLogs    AuditLog[]
   importJobs   ImportJob[]
+  requests     Request[]
 }
 
 model Role {
@@ -65,6 +66,7 @@ model Flavor {
   description String?
   profile     String?
   stocks      Stock[]
+  requests    Request[]
 }
 
 model AuditLog {
@@ -94,4 +96,15 @@ model ImportJob {
   status       String   @default("pending")
   errors       Json?
   createdAt    DateTime @default(now())
+}
+
+model Request {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    Int
+  flavor    Flavor   @relation(fields: [flavorId], references: [id])
+  flavorId  Int
+  quantity  Int
+  status    String   @default("pending")
+  createdAt DateTime @default(now())
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { StockModule } from './stocks/stock.module';
 import { UsersModule } from './users/users.module';
 import { AuditModule } from './audit/audit.module';
 import { RolesModule } from './roles/roles.module';
+import { RequestsModule } from './requests/requests.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { RolesModule } from './roles/roles.module';
     StockModule,
     UsersModule,
     RolesModule,
+    RequestsModule,
     AuditModule,
   ],
   providers: [],

--- a/backend/src/requests/dto/create-request.dto.ts
+++ b/backend/src/requests/dto/create-request.dto.ts
@@ -1,0 +1,9 @@
+import { IsInt } from 'class-validator';
+
+export class CreateRequestDto {
+  @IsInt()
+  flavorId: number;
+
+  @IsInt()
+  quantity: number;
+}

--- a/backend/src/requests/dto/update-request-status.dto.ts
+++ b/backend/src/requests/dto/update-request-status.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class UpdateRequestStatusDto {
+  @IsString()
+  status: string;
+}

--- a/backend/src/requests/requests.controller.ts
+++ b/backend/src/requests/requests.controller.ts
@@ -1,0 +1,37 @@
+import { Body, Controller, Get, Param, ParseIntPipe, Post, Put, UseGuards } from '@nestjs/common';
+import { RequestsService } from './requests.service';
+import { CreateRequestDto } from './dto/create-request.dto';
+import { UpdateRequestStatusDto } from './dto/update-request-status.dto';
+import { AuthGuard } from '../auth/auth.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permission } from '../auth/permission.decorator';
+import { User } from '../auth/user.decorator';
+
+@Controller('requests')
+export class RequestsController {
+  constructor(private requests: RequestsService) {}
+
+  @Get()
+  @UseGuards(AuthGuard, PermissionsGuard)
+  @Permission('view_requests')
+  list() {
+    return this.requests.list();
+  }
+
+  @Post()
+  @UseGuards(AuthGuard)
+  create(@Body() dto: CreateRequestDto, @User() user) {
+    return this.requests.create(dto, user.id);
+  }
+
+  @Put(':id/status')
+  @UseGuards(AuthGuard, PermissionsGuard)
+  @Permission('approve_requests')
+  updateStatus(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateRequestStatusDto,
+    @User() user,
+  ) {
+    return this.requests.updateStatus(id, dto.status, user.id);
+  }
+}

--- a/backend/src/requests/requests.module.ts
+++ b/backend/src/requests/requests.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { RequestsController } from './requests.controller';
+import { RequestsService } from './requests.service';
+import { PrismaService } from '../prisma.service';
+import { AuditService } from '../audit/audit.service';
+
+@Module({
+  controllers: [RequestsController],
+  providers: [RequestsService, PrismaService, AuditService],
+})
+export class RequestsModule {}

--- a/backend/src/requests/requests.service.ts
+++ b/backend/src/requests/requests.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { CreateRequestDto } from './dto/create-request.dto';
+
+@Injectable()
+export class RequestsService {
+  constructor(private prisma: PrismaService, private audit: AuditService) {}
+
+  list() {
+    return this.prisma.request.findMany({
+      include: {
+        user: { select: { id: true, firstName: true, lastName: true } },
+        flavor: { select: { id: true, name: true } },
+      },
+    });
+  }
+
+  async create(dto: CreateRequestDto, userId: number) {
+    const request = await this.prisma.request.create({
+      data: {
+        flavorId: dto.flavorId,
+        quantity: dto.quantity,
+        userId,
+      },
+    });
+    await this.audit.log('Request', request.id, 'CREATE', userId, dto);
+    return request;
+  }
+
+  async updateStatus(id: number, status: string, userId: number) {
+    const request = await this.prisma.request.update({
+      where: { id },
+      data: { status },
+    });
+    await this.audit.log('Request', id, 'UPDATE', userId, { status });
+    return request;
+  }
+}


### PR DESCRIPTION
## Summary
- support Telegram stock requests via new RequestsModule
- log Request creation and status updates in Audit logs
- extend schema with Request model
- wire RequestsModule into AppModule

## Testing
- `npx prisma generate`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a85250fd483329cd06d95d75a1ca4