### PR TITLE
Add permissions seeder

### DIFF
--- a/backend/src/seed/permissions.seed.ts
+++ b/backend/src/seed/permissions.seed.ts
@@ -1,0 +1,27 @@
+import { PrismaService } from '../prisma.service';
+
+export const permissions = [
+  { code: 'view_logs', description: 'Просмотр логов активности' },
+  { code: 'import_data', description: 'Импорт данных' },
+  { code: 'export_data', description: 'Экспорт данных' },
+  { code: 'delete_flavor', description: 'Удаление вкусов' },
+  { code: 'manage_users', description: 'Управление пользователями' },
+  { code: 'manage_roles', description: 'Управление ролями' },
+  { code: 'view_requests', description: 'Просмотр заявок' },
+  { code: 'approve_requests', description: 'Подтверждение заявок' },
+];
+
+export async function run() {
+  const prisma = new PrismaService();
+  await prisma.$connect();
+
+  for (const perm of permissions) {
+    await prisma.permission.upsert({
+      where: { code: perm.code },
+      update: {},
+      create: perm,
+    });
+  }
+
+  await prisma.$disconnect();
+}


### PR DESCRIPTION
## Summary
- add `permissions.seed.ts` with a list of default permissions and a `run()` helper

## Testing
- `npx tsc --noEmit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a88b079bc833284266870385a9a5c