### PR TITLE
Add export flavors endpoint

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,8 @@
     "rxjs": "^7.8.1",
     "multer": "^1.4.5-lts.1",
     "csv-parse": "^5.5.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "csv-stringify": "^6.3.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { AuditModule } from './audit/audit.module';
 import { RolesModule } from './roles/roles.module';
 import { RequestsModule } from './requests/requests.module';
 import { ImportModule } from './import/import.module';
+import { ExportModule } from './export/export.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { ImportModule } from './import/import.module';
     RequestsModule,
     AuditModule,
     ImportModule,
+    ExportModule,
   ],
   providers: [],
 })

--- a/backend/src/export/export.controller.ts
+++ b/backend/src/export/export.controller.ts
@@ -1,0 +1,53 @@
+import { BadRequestException, Controller, Get, Query, Res, UseGuards } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { AuthGuard } from '../auth/auth.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permission } from '../auth/permission.decorator';
+import { stringify } from 'csv-stringify/sync';
+import * as xlsx from 'xlsx';
+
+@Controller('export')
+@UseGuards(AuthGuard, PermissionsGuard)
+@Permission('export_data')
+export class ExportController {
+  constructor(private prisma: PrismaService) {}
+
+  @Get('flavors')
+  async exportFlavors(@Query('format') format = 'csv', @Res() res) {
+    if (format !== 'csv' && format !== 'xlsx') {
+      throw new BadRequestException('Invalid format');
+    }
+
+    const flavors = await this.prisma.flavor.findMany({
+      include: { brand: { select: { name: true } } },
+    });
+
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Disposition', `attachment; filename="flavors.${format}"`);
+
+    if (format === 'csv') {
+      const records = flavors.map(f => ({
+        id: f.id,
+        brand: f.brand.name,
+        name: f.name,
+        description: f.description ?? '',
+        profile: f.profile ?? '',
+      }));
+      const csv = stringify(records, { header: true });
+      res.send(csv);
+    } else {
+      const data = flavors.map(f => ({
+        id: f.id,
+        brand: f.brand.name,
+        name: f.name,
+        description: f.description ?? '',
+        profile: f.profile ?? '',
+      }));
+      const ws = xlsx.utils.json_to_sheet(data);
+      const wb = xlsx.utils.book_new();
+      xlsx.utils.book_append_sheet(wb, ws, 'Flavors');
+      const buffer = xlsx.write(wb, { type: 'buffer', bookType: 'xlsx' });
+      res.send(buffer);
+    }
+  }
+}

--- a/backend/src/export/export.module.ts
+++ b/backend/src/export/export.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ExportController } from './export.controller';
+import { PrismaService } from '../prisma.service';
+
+@Module({
+  controllers: [ExportController],
+  providers: [PrismaService],
+})
+export class ExportModule {}


### PR DESCRIPTION
## Summary
- add csv-stringify as new dependency
- implement `ExportController` with `GET /export/flavors`
- register `ExportModule` in `AppModule`

## Testing
- `npx tsc --noEmit` *(fails: Module '@prisma/client' has no exported member 'ImportJob')*

------
https://chatgpt.com/codex/tasks/task_e_687a9864854883328484e987a2a174b8