### PR TITLE
Implement audit logs endpoint

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { AuditModule } from './audit/audit.module';
 import { RolesModule } from './roles/roles.module';
 import { RequestsModule } from './requests/requests.module';
 import { ImportModule } from './import/import.module';
+import { AuditLogsModule } from './audit-logs/audit-logs.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { ImportModule } from './import/import.module';
     RolesModule,
     RequestsModule,
     AuditModule,
+    AuditLogsModule,
     ImportModule,
   ],
   providers: [],

--- a/backend/src/audit-logs/audit-logs.controller.ts
+++ b/backend/src/audit-logs/audit-logs.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Query, DefaultValuePipe, ParseIntPipe, UseGuards } from '@nestjs/common';
+import { AuditService } from '../audit/audit.service';
+import { AuthGuard } from '../auth/auth.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permission } from '../auth/permission.decorator';
+
+@Controller('audit-logs')
+@UseGuards(AuthGuard, PermissionsGuard)
+export class AuditLogsController {
+  constructor(private audit: AuditService) {}
+
+  @Get()
+  @Permission('view_logs')
+  list(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('pageSize', new DefaultValuePipe(20), ParseIntPipe) pageSize: number,
+  ) {
+    return this.audit.paginate(page, pageSize);
+  }
+}

--- a/backend/src/audit-logs/audit-logs.module.ts
+++ b/backend/src/audit-logs/audit-logs.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AuditLogsController } from './audit-logs.controller';
+import { AuditService } from '../audit/audit.service';
+import { PrismaService } from '../prisma.service';
+
+@Module({
+  controllers: [AuditLogsController],
+  providers: [AuditService, PrismaService],
+})
+export class AuditLogsModule {}

--- a/backend/src/audit/audit.service.ts
+++ b/backend/src/audit/audit.service.ts
@@ -48,4 +48,34 @@ export class AuditService {
       user: { id: l.user.id, fullName: `${l.user.firstName} ${l.user.lastName}` },
     }));
   }
+
+  async paginate(page = 1, pageSize = 20) {
+    const [total, logs] = await this.prisma.$transaction([
+      this.prisma.auditLog.count(),
+      this.prisma.auditLog.findMany({
+        orderBy: { id: 'desc' },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+        include: {
+          user: { select: { id: true, firstName: true, lastName: true } },
+        },
+      }),
+    ]);
+    return {
+      total,
+      items: logs.map(l => ({
+        id: l.id,
+        user: {
+          id: l.user.id,
+          firstName: l.user.firstName,
+          lastName: l.user.lastName,
+        },
+        entity: l.entity,
+        entityId: l.entityId,
+        action: l.action,
+        timestamp: l.timestamp,
+        details: l.details,
+      })),
+    };
+  }
 }


### PR DESCRIPTION
## Summary
- add AuditLogsController and AuditLogsModule
- extend AuditService with paginate() helper
- register AuditLogsModule in AppModule

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687b7c73931c8332ada69a37c4f3638f