### PR TITLE
Add ExportController for flavor data

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { RolesModule } from './roles/roles.module';
 import { RequestsModule } from './requests/requests.module';
 import { ImportModule } from './import/import.module';
 import { AuditLogsModule } from './audit-logs/audit-logs.module';
+import { ExportModule } from './export/export.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { AuditLogsModule } from './audit-logs/audit-logs.module';
     AuditModule,
     AuditLogsModule,
     ImportModule,
+    ExportModule,
   ],
   providers: [],
 })

--- a/backend/src/export/export.controller.ts
+++ b/backend/src/export/export.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Res, UseGuards } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { AuthGuard } from '../auth/auth.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permission } from '../auth/permission.decorator';
+import * as xlsx from 'xlsx';
+
+@Controller('export')
+@UseGuards(AuthGuard, PermissionsGuard)
+export class ExportController {
+  constructor(private prisma: PrismaService) {}
+
+  @Get('flavors')
+  @Permission('export_data')
+  async exportFlavors(@Res() res) {
+    const flavors = await this.prisma.flavor.findMany({
+      include: { brand: { select: { name: true } } },
+    });
+    const data = flavors.map(f => ({
+      id: f.id,
+      name: f.name,
+      description: f.description ?? '',
+      profile: f.profile ?? '',
+      brand: f.brand.name,
+    }));
+    const ws = xlsx.utils.json_to_sheet(data);
+    const wb = xlsx.utils.book_new();
+    xlsx.utils.book_append_sheet(wb, ws, 'Flavors');
+    const buffer = xlsx.write(wb, { type: 'buffer', bookType: 'xlsx' });
+
+    res.setHeader(
+      'Content-Type',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+    res.setHeader('Content-Disposition', 'attachment; filename="flavors.xlsx"');
+    res.send(buffer);
+  }
+}

--- a/backend/src/export/export.module.ts
+++ b/backend/src/export/export.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ExportController } from './export.controller';
+import { PrismaService } from '../prisma.service';
+
+@Module({
+  controllers: [ExportController],
+  providers: [PrismaService],
+})
+export class ExportModule {}


### PR DESCRIPTION
## Summary
- implement `ExportController` with `/export/flavors` route
- create `ExportModule` and register it in `AppModule`

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_687b7f5245508332a5e0631dd6e959f5