### PR TITLE
Add full role management API

### DIFF
--- a/backend/src/roles/dto/create-role.dto.ts
+++ b/backend/src/roles/dto/create-role.dto.ts
@@ -1,7 +1,12 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { ArrayUnique, IsArray, IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateRoleDto {
   @IsString()
   @IsNotEmpty()
   name: string;
+
+  @IsArray()
+  @ArrayUnique()
+  @IsString({ each: true })
+  permissions: string[];
 }

--- a/backend/src/roles/dto/update-role.dto.ts
+++ b/backend/src/roles/dto/update-role.dto.ts
@@ -1,0 +1,13 @@
+import { ArrayUnique, IsArray, IsOptional, IsString } from 'class-validator';
+
+export class UpdateRoleDto {
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @IsArray()
+  @ArrayUnique()
+  @IsString({ each: true })
+  @IsOptional()
+  permissions?: string[];
+}

--- a/backend/src/roles/roles.controller.ts
+++ b/backend/src/roles/roles.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, UseGuards } from '@nestjs/common';
 import { RolesService } from './roles.service';
 import { CreateRoleDto } from './dto/create-role.dto';
-import { UpdatePermissionsDto } from './dto/update-permissions.dto';
+import { UpdateRoleDto } from './dto/update-role.dto';
 import { AuthGuard } from '../auth/auth.guard';
 import { PermissionsGuard } from '../auth/permissions.guard';
 import { Permission } from '../auth/permission.decorator';
@@ -12,6 +12,8 @@ export class RolesController {
   constructor(private roles: RolesService) {}
 
   @Get()
+  @UseGuards(AuthGuard, PermissionsGuard)
+  @Permission('manage_roles')
   list() {
     return this.roles.list();
   }
@@ -31,14 +33,14 @@ export class RolesController {
     return { success: true };
   }
 
-  @Put(':id/permissions')
+  @Put(':id')
   @UseGuards(AuthGuard, PermissionsGuard)
   @Permission('manage_roles')
-  updatePermissions(
+  update(
     @Param('id', ParseIntPipe) id: number,
-    @Body() dto: UpdatePermissionsDto,
+    @Body() dto: UpdateRoleDto,
     @User() user,
   ) {
-    return this.roles.updatePermissions(id, dto.permissions, user.id);
+    return this.roles.update(id, dto, user.id);
   }
 }

--- a/backend/src/roles/roles.service.ts
+++ b/backend/src/roles/roles.service.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { CreateRoleDto } from './dto/create-role.dto';
+import { UpdateRoleDto } from './dto/update-role.dto';
 
 @Injectable()
 export class RolesService {
@@ -20,32 +21,83 @@ export class RolesService {
 
   async create(dto: CreateRoleDto, userId: number) {
     const role = await this.prisma.role.create({ data: { name: dto.name } });
-    await this.audit.log('Role', role.id, 'CREATE', userId, { name: dto.name });
-    return role;
+
+    if (dto.permissions && dto.permissions.length > 0) {
+      const permissions = await this.prisma.permission.findMany({
+        where: { code: { in: dto.permissions } },
+        select: { id: true },
+      });
+      if (permissions.length > 0) {
+        await this.prisma.rolePermission.createMany({
+          data: permissions.map(p => ({ roleId: role.id, permissionId: p.id })),
+        });
+      }
+    }
+
+    const result = await this.prisma.role.findUnique({
+      where: { id: role.id },
+      include: { permissions: { include: { permission: true } } },
+    });
+
+    await this.audit.log('Role', role.id, 'CREATE', userId, {
+      name: dto.name,
+      permissions: dto.permissions,
+    });
+
+    return {
+      id: result.id,
+      name: result.name,
+      permissions: result.permissions.map(rp => rp.permission),
+    };
   }
 
   async remove(id: number, userId: number) {
+    const count = await this.prisma.user.count({ where: { roleId: id } });
+    if (count > 0) {
+      throw new BadRequestException(
+        'Cannot delete a role that is assigned to users',
+      );
+    }
+
     await this.prisma.role.delete({ where: { id } });
     await this.audit.log('Role', id, 'DELETE', userId, {});
   }
 
-  async updatePermissions(roleId: number, codes: string[], userId: number) {
-    const permissions = await this.prisma.permission.findMany({
-      where: { code: { in: codes } },
-      select: { id: true },
-    });
+  async update(roleId: number, dto: UpdateRoleDto, userId: number) {
+    const data: any = {};
+    if (dto.name !== undefined) data.name = dto.name;
 
-    await this.prisma.rolePermission.deleteMany({ where: { roleId } });
-    if (permissions.length > 0) {
-      await this.prisma.rolePermission.createMany({
-        data: permissions.map(p => ({ roleId, permissionId: p.id })),
-      });
+    if (Object.keys(data).length > 0) {
+      await this.prisma.role.update({ where: { id: roleId }, data });
     }
 
-    await this.audit.log('Role', roleId, 'UPDATE', userId, { permissions: codes });
-    return this.prisma.role.findUnique({
+    if (dto.permissions) {
+      const permissions = await this.prisma.permission.findMany({
+        where: { code: { in: dto.permissions } },
+        select: { id: true },
+      });
+      await this.prisma.rolePermission.deleteMany({ where: { roleId } });
+      if (permissions.length > 0) {
+        await this.prisma.rolePermission.createMany({
+          data: permissions.map(p => ({ roleId, permissionId: p.id })),
+        });
+      }
+    }
+
+    const result = await this.prisma.role.findUnique({
       where: { id: roleId },
       include: { permissions: { include: { permission: true } } },
     });
+
+    const diff = Object.fromEntries(
+      Object.entries(dto).filter(([, v]) => v !== undefined),
+    );
+    await this.audit.log('Role', roleId, 'UPDATE', userId, diff);
+
+    return {
+      id: result.id,
+      name: result.name,
+      permissions: result.permissions.map(rp => rp.permission),
+    };
   }
 }


### PR DESCRIPTION
## Summary
- extend `CreateRoleDto` with permissions
- add `UpdateRoleDto`
- protect all role endpoints with permission checks
- implement role create/update with permission links
- block deletion when the role is in use

## Testing
- `npx tsc -p backend/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_687b859a58ec8332b7b7528450284fab