### PR TITLE
Add updated Requests module

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -66,7 +66,7 @@ model Flavor {
   description String?
   profile     String?
   stocks      Stock[]
-  requests    Request[]
+  requests    RequestFlavor[]
 }
 
 model AuditLog {
@@ -98,13 +98,27 @@ model ImportJob {
   createdAt    DateTime @default(now())
 }
 
+enum RequestStatus {
+  pending
+  approved
+  rejected
+}
+
 model Request {
-  id        Int      @id @default(autoincrement())
-  user      User     @relation(fields: [userId], references: [id])
-  userId    Int
-  flavor    Flavor   @relation(fields: [flavorId], references: [id])
+  id          Int           @id @default(autoincrement())
+  status      RequestStatus @default(pending)
+  comment     String?
+  createdAt   DateTime      @default(now())
+  createdBy   User          @relation(fields: [createdById], references: [id])
+  createdById Int
+  flavors     RequestFlavor[]
+}
+
+model RequestFlavor {
+  request   Request @relation(fields: [requestId], references: [id])
+  requestId Int
+  flavor    Flavor  @relation(fields: [flavorId], references: [id])
   flavorId  Int
-  quantity  Int
-  status    String   @default("pending")
-  createdAt DateTime @default(now())
+
+  @@id([requestId, flavorId])
 }

--- a/backend/src/requests/dto/create-request.dto.ts
+++ b/backend/src/requests/dto/create-request.dto.ts
@@ -1,9 +1,12 @@
-import { IsInt } from 'class-validator';
+import { IsArray, IsInt, IsOptional, IsString, ArrayNotEmpty } from 'class-validator';
 
 export class CreateRequestDto {
-  @IsInt()
-  flavorId: number;
+  @IsString()
+  @IsOptional()
+  comment?: string;
 
-  @IsInt()
-  quantity: number;
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsInt({ each: true })
+  flavorIds: number[];
 }

--- a/backend/src/requests/dto/update-request-status.dto.ts
+++ b/backend/src/requests/dto/update-request-status.dto.ts
@@ -1,6 +1,0 @@
-import { IsString } from 'class-validator';
-
-export class UpdateRequestStatusDto {
-  @IsString()
-  status: string;
-}

--- a/backend/src/requests/dto/update-request.dto.ts
+++ b/backend/src/requests/dto/update-request.dto.ts
@@ -1,0 +1,17 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+
+export enum RequestStatusEnum {
+  pending = 'pending',
+  approved = 'approved',
+  rejected = 'rejected',
+}
+
+export class UpdateRequestDto {
+  @IsEnum(RequestStatusEnum)
+  @IsOptional()
+  status?: RequestStatusEnum;
+
+  @IsString()
+  @IsOptional()
+  comment?: string;
+}

--- a/backend/src/requests/requests.controller.ts
+++ b/backend/src/requests/requests.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Get, Param, ParseIntPipe, Post, Put, UseGuards } from '@nestjs/common';
 import { RequestsService } from './requests.service';
 import { CreateRequestDto } from './dto/create-request.dto';
-import { UpdateRequestStatusDto } from './dto/update-request-status.dto';
+import { UpdateRequestDto } from './dto/update-request.dto';
 import { AuthGuard } from '../auth/auth.guard';
 import { PermissionsGuard } from '../auth/permissions.guard';
 import { Permission } from '../auth/permission.decorator';
@@ -24,14 +24,14 @@ export class RequestsController {
     return this.requests.create(dto, user.id);
   }
 
-  @Put(':id/status')
+  @Put(':id')
   @UseGuards(AuthGuard, PermissionsGuard)
   @Permission('approve_requests')
-  updateStatus(
+  update(
     @Param('id', ParseIntPipe) id: number,
-    @Body() dto: UpdateRequestStatusDto,
+    @Body() dto: UpdateRequestDto,
     @User() user,
   ) {
-    return this.requests.updateStatus(id, dto.status, user.id);
+    return this.requests.update(id, dto, user.id);
   }
 }


### PR DESCRIPTION
## Summary
- update Prisma schema with RequestStatus enum and Request/RequestFlavor models
- support comments and multiple flavors in CreateRequestDto
- add UpdateRequestDto for status and comment updates
- implement RequestsService with create, list, and update methods
- adjust RequestsController routes for new service

## Testing
- `npx prisma generate`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_687b88e205608332aa1d93d9ee0e6665