### PR TITLE
Add audit log viewer

### DIFF
--- a/backend/src/audit-logs/audit-logs.controller.ts
+++ b/backend/src/audit-logs/audit-logs.controller.ts
@@ -1,5 +1,12 @@
-import { Controller, Get, Query, DefaultValuePipe, ParseIntPipe, UseGuards } from '@nestjs/common';
-import { AuditService } from '../audit/audit.service';
+import {
+  Controller,
+  Get,
+  Query,
+  DefaultValuePipe,
+  ParseIntPipe,
+  UseGuards,
+} from '@nestjs/common';
+import { AuditLogsService } from './audit-logs.service';
 import { AuthGuard } from '../auth/auth.guard';
 import { PermissionsGuard } from '../auth/permissions.guard';
 import { Permission } from '../auth/permission.decorator';
@@ -7,14 +14,16 @@ import { Permission } from '../auth/permission.decorator';
 @Controller('audit-logs')
 @UseGuards(AuthGuard, PermissionsGuard)
 export class AuditLogsController {
-  constructor(private audit: AuditService) {}
+  constructor(private logs: AuditLogsService) {}
 
   @Get()
   @Permission('view_logs')
   list(
-    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
-    @Query('pageSize', new DefaultValuePipe(20), ParseIntPipe) pageSize: number,
+    @Query('entity') entity?: string,
+    @Query('userId', ParseIntPipe) userId?: number,
+    @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit = 50,
+    @Query('offset', new DefaultValuePipe(0), ParseIntPipe) offset = 0,
   ) {
-    return this.audit.paginate(page, pageSize);
+    return this.logs.list(entity, userId, limit, offset);
   }
 }

--- a/backend/src/audit-logs/audit-logs.module.ts
+++ b/backend/src/audit-logs/audit-logs.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AuditLogsController } from './audit-logs.controller';
-import { AuditService } from '../audit/audit.service';
 import { PrismaService } from '../prisma.service';
+import { AuditLogsService } from './audit-logs.service';
 
 @Module({
   controllers: [AuditLogsController],
-  providers: [AuditService, PrismaService],
+  providers: [AuditLogsService, PrismaService],
 })
 export class AuditLogsModule {}

--- a/backend/src/audit-logs/audit-logs.service.ts
+++ b/backend/src/audit-logs/audit-logs.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class AuditLogsService {
+  constructor(private prisma: PrismaService) {}
+
+  async list(
+    entity?: string,
+    userId?: number,
+    limit = 50,
+    offset = 0,
+  ) {
+    const where: any = {};
+    if (entity) where.entity = entity;
+    if (userId !== undefined) where.userId = userId;
+
+    const logs = await this.prisma.auditLog.findMany({
+      where,
+      orderBy: { timestamp: 'desc' },
+      take: limit,
+      skip: offset,
+      include: { user: { select: { id: true, firstName: true, lastName: true } } },
+    });
+
+    return logs.map(l => ({
+      id: l.id,
+      entity: l.entity,
+      entityId: l.entityId,
+      action: l.action,
+      user: { id: l.user.id, firstName: l.user.firstName, lastName: l.user.lastName },
+      timestamp: l.timestamp,
+      details: l.details,
+    }));
+  }
+}


### PR DESCRIPTION
## Summary
- implement `AuditLogsService` for filtering logs by entity and user
- update `AuditLogsController` to expose `GET /audit-logs` with filters and pagination
- register new service in `AuditLogsModule`

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_687bf648d0048332884d4f4796ff1269