### PR TITLE
Add dashboard summary endpoint

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { RequestsModule } from './requests/requests.module';
 import { ImportModule } from './import/import.module';
 import { AuditLogsModule } from './audit-logs/audit-logs.module';
 import { ExportModule } from './export/export.module';
+import { DashboardModule } from './dashboard/dashboard.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { ExportModule } from './export/export.module';
     AuditLogsModule,
     ImportModule,
     ExportModule,
+    DashboardModule,
   ],
   providers: [],
 })

--- a/backend/src/dashboard/dashboard.controller.ts
+++ b/backend/src/dashboard/dashboard.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { DashboardService } from './dashboard.service';
+import { AuthGuard } from '../auth/auth.guard';
+import { PermissionsGuard } from '../auth/permissions.guard';
+import { Permission } from '../auth/permission.decorator';
+
+@Controller('dashboard')
+@UseGuards(AuthGuard, PermissionsGuard)
+export class DashboardController {
+  constructor(private dashboard: DashboardService) {}
+
+  @Get('summary')
+  @Permission('view_requests')
+  summary() {
+    return this.dashboard.summary();
+  }
+}

--- a/backend/src/dashboard/dashboard.module.ts
+++ b/backend/src/dashboard/dashboard.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+import { PrismaService } from '../prisma.service';
+
+@Module({
+  controllers: [DashboardController],
+  providers: [DashboardService, PrismaService],
+})
+export class DashboardModule {}

--- a/backend/src/dashboard/dashboard.service.ts
+++ b/backend/src/dashboard/dashboard.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class DashboardService {
+  constructor(private prisma: PrismaService) {}
+
+  async summary() {
+    const [
+      usersCount,
+      brandsCount,
+      flavorsCount,
+      requestsCount,
+      pendingCount,
+      approvedCount,
+      rejectedCount,
+      latestRequests,
+    ] = await this.prisma.$transaction([
+      this.prisma.user.count(),
+      this.prisma.brand.count(),
+      this.prisma.flavor.count(),
+      this.prisma.request.count(),
+      this.prisma.request.count({ where: { status: 'pending' } }),
+      this.prisma.request.count({ where: { status: 'approved' } }),
+      this.prisma.request.count({ where: { status: 'rejected' } }),
+      this.prisma.request.findMany({
+        orderBy: { createdAt: 'desc' },
+        take: 5,
+        include: {
+          createdBy: { select: { id: true, firstName: true, lastName: true } },
+          flavors: { include: { flavor: { select: { id: true, name: true } } } },
+        },
+      }),
+    ]);
+
+    return {
+      usersCount,
+      brandsCount,
+      flavorsCount,
+      requestsCount,
+      requestsByStatus: {
+        pending: pendingCount,
+        approved: approvedCount,
+        rejected: rejectedCount,
+      },
+      latestRequests: latestRequests.map(r => ({
+        id: r.id,
+        status: r.status,
+        createdAt: r.createdAt,
+        comment: r.comment,
+        user: {
+          id: r.createdBy.id,
+          firstName: r.createdBy.firstName,
+          lastName: r.createdBy.lastName,
+        },
+        flavors: r.flavors.map(f => f.flavor),
+      })),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- implement dashboard module with summary endpoint
- aggregate counts and latest requests for dashboard
- register `DashboardModule` in `AppModule`

## Testing
- `npx --yes tsc -p backend/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_687bf85421ec8332b514c9a8078bc411