### PR TITLE
Add roles page

### DIFF
--- a/frontend/app/(main)/roles/page.tsx
+++ b/frontend/app/(main)/roles/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { useEffect, useState } from 'react';
+import api from '../../../lib/api';
+import AuthGuard from '../../../components/AuthGuard';
+import Spinner from '../../../components/Spinner';
+import RoleTable from '../../../components/RoleTable';
+
+interface ApiRole {
+  id: number;
+  name: string;
+  permissions: { id: number; code: string; description: string }[];
+}
+
+export default function RolesPage() {
+  const [roles, setRoles] = useState<ApiRole[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api
+      .get<ApiRole[]>('/roles')
+      .then(res => setRoles(res.data))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <AuthGuard>
+      <div className="space-y-4">
+        {loading ? <Spinner /> : <RoleTable roles={roles} />}
+      </div>
+    </AuthGuard>
+  );
+}

--- a/frontend/components/RoleTable.tsx
+++ b/frontend/components/RoleTable.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface Role {
+  id: number;
+  name: string;
+  permissions: { id: number; code: string; description: string }[];
+}
+
+export default function RoleTable({ roles }: { roles: Role[] }) {
+  return (
+    <table className="w-full text-sm text-left bg-[#1E1E1E] rounded">
+      <thead>
+        <tr>
+          <th className="p-2">ID</th>
+          <th className="p-2">Name</th>
+          <th className="p-2">Permissions</th>
+          <th className="p-2">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {roles.map(role => (
+          <tr key={role.id} className="border-t border-gray-700">
+            <td className="p-2">{role.id}</td>
+            <td className="p-2">{role.name}</td>
+            <td className="p-2">{role.permissions.map(p => p.code).join(', ')}</td>
+            <td className="p-2">
+              <button className="px-2 py-1 bg-accent text-black rounded">Edit</button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
## Summary
- implement roles page
- add RoleTable component for displaying roles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c0081cfb8833299bf8117cb1f843b