### PR TITLE
Add permissions page

### DIFF
--- a/frontend/app/(main)/permissions/page.tsx
+++ b/frontend/app/(main)/permissions/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { useEffect, useState } from 'react';
+import api from '../../../lib/api';
+import AuthGuard from '../../../components/AuthGuard';
+import Spinner from '../../../components/Spinner';
+import PermissionTable from '../../../components/PermissionTable';
+
+interface ApiPermission {
+  id: number;
+  code: string;
+  description: string;
+}
+
+export default function PermissionsPage() {
+  const [permissions, setPermissions] = useState<ApiPermission[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api
+      .get<ApiPermission[]>('/permissions')
+      .then(res => setPermissions(res.data))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <AuthGuard>
+      <div className="space-y-4">
+        {loading ? <Spinner /> : <PermissionTable permissions={permissions} />}
+      </div>
+    </AuthGuard>
+  );
+}

--- a/frontend/components/PermissionTable.tsx
+++ b/frontend/components/PermissionTable.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface Permission {
+  id: number;
+  code: string;
+  description: string;
+}
+
+export default function PermissionTable({ permissions }: { permissions: Permission[] }) {
+  return (
+    <table className="w-full text-sm text-left bg-[#1E1E1E] rounded">
+      <thead>
+        <tr>
+          <th className="p-2">ID</th>
+          <th className="p-2">Code</th>
+          <th className="p-2">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {permissions.map(p => (
+          <tr key={p.id} className="border-t border-gray-700">
+            <td className="p-2">{p.id}</td>
+            <td className="p-2">{p.code}</td>
+            <td className="p-2">{p.description}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
## Summary
- add PermissionTable component
- add `/permissions` page to show all permissions in a table

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c01d8bd7c83328faee37c49e12b2c