### PR TITLE
Add role edit page

### DIFF
--- a/frontend/app/(main)/roles/[id]/page.tsx
+++ b/frontend/app/(main)/roles/[id]/page.tsx
@@ -1,0 +1,110 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import AuthGuard from '../../../../components/AuthGuard';
+import Spinner from '../../../../components/Spinner';
+import api from '../../../../lib/api';
+
+interface ApiPermission {
+  id: number;
+  code: string;
+  description: string;
+}
+
+interface ApiRole {
+  id: number;
+  name: string;
+  permissions: ApiPermission[];
+}
+
+export default function RoleEditPage() {
+  const params = useParams<{ id: string }>();
+  const [role, setRole] = useState<ApiRole | null>(null);
+  const [permissions, setPermissions] = useState<ApiPermission[]>([]);
+  const [name, setName] = useState('');
+  const [selected, setSelected] = useState<number[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const fetchData = () => {
+    setLoading(true);
+    Promise.all([
+      api.get<ApiRole>(`/roles/${params.id}`),
+      api.get<ApiPermission[]>('/permissions'),
+    ])
+      .then(([roleRes, permsRes]) => {
+        setRole(roleRes.data);
+        setName(roleRes.data.name);
+        setSelected(roleRes.data.permissions.map(p => p.id));
+        setPermissions(permsRes.data);
+      })
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(fetchData, [params.id]);
+
+  const togglePermission = (id: number) => {
+    setSelected(prev =>
+      prev.includes(id) ? prev.filter(p => p !== id) : [...prev, id]
+    );
+  };
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!role) return;
+    setSaving(true);
+    try {
+      await api.put(`/roles/${params.id}`, {
+        name,
+        permissionIds: selected,
+      });
+      fetchData();
+    } catch (err) {
+      alert('Failed to save role');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <AuthGuard>
+      {loading || !role ? (
+        <Spinner />
+      ) : (
+        <form onSubmit={onSubmit} className="space-y-4 max-w-md">
+          <div>
+            <label className="block mb-1">Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              className="w-full p-2 bg-[#1E1E1E] rounded"
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Permissions</label>
+            <div className="space-y-1">
+              {permissions.map(p => (
+                <label key={p.id} className="flex items-center space-x-2">
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(p.id)}
+                    onChange={() => togglePermission(p.id)}
+                  />
+                  <span>{p.code}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-4 py-2 bg-accent text-black rounded disabled:opacity-50"
+          >
+            {saving ? 'Saving...' : 'Save Changes'}
+          </button>
+        </form>
+      )}
+    </AuthGuard>
+  );
+}

--- a/frontend/components/RoleTable.tsx
+++ b/frontend/components/RoleTable.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 
 interface Role {
   id: number;
@@ -24,7 +25,9 @@ export default function RoleTable({ roles }: { roles: Role[] }) {
             <td className="p-2">{role.name}</td>
             <td className="p-2">{role.permissions.map(p => p.code).join(', ')}</td>
             <td className="p-2">
-              <button className="px-2 py-1 bg-accent text-black rounded">Edit</button>
+              <Link href={`/roles/${role.id}`} className="px-2 py-1 bg-accent text-black rounded">
+                Edit
+              </Link>
             </td>
           </tr>
         ))}


### PR DESCRIPTION
## Summary
- add dynamic route `/roles/[id]` for editing a role
- allow editing role name and permission assignments
- link RoleTable rows to the edit page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c0625b0f88332a59d1029386c68ee