### PR TITLE
Add new user creation page

### DIFF
--- a/frontend/app/(main)/users/new/page.tsx
+++ b/frontend/app/(main)/users/new/page.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import AuthGuard from '../../../../components/AuthGuard';
+import Spinner from '../../../../components/Spinner';
+import api from '../../../../lib/api';
+
+interface ApiRole {
+  id: number;
+  name: string;
+}
+
+export default function UserCreatePage() {
+  const router = useRouter();
+  const [roles, setRoles] = useState<ApiRole[]>([]);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [roleId, setRoleId] = useState<number | ''>('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    api
+      .get<ApiRole[]>('/roles')
+      .then(res => setRoles(res.data))
+      .catch(() => setError('Failed to load roles'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError('');
+    try {
+      await api.post('/users', {
+        firstName,
+        lastName,
+        username: email,
+        password,
+        roleId: Number(roleId),
+      });
+      router.push('/users');
+    } catch (err) {
+      setError('Failed to create user');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <AuthGuard>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <form onSubmit={onSubmit} className="space-y-4 max-w-md">
+          {error && <p className="text-red-500">{error}</p>}
+          <div>
+            <label className="block mb-1">First Name</label>
+            <input
+              type="text"
+              value={firstName}
+              onChange={e => setFirstName(e.target.value)}
+              className="w-full p-2 bg-[#1E1E1E] rounded"
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Last Name</label>
+            <input
+              type="text"
+              value={lastName}
+              onChange={e => setLastName(e.target.value)}
+              className="w-full p-2 bg-[#1E1E1E] rounded"
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Email</label>
+            <input
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              className="w-full p-2 bg-[#1E1E1E] rounded"
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Password</label>
+            <input
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              className="w-full p-2 bg-[#1E1E1E] rounded"
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Role</label>
+            <select
+              value={roleId}
+              onChange={e => setRoleId(Number(e.target.value))}
+              className="w-full p-2 bg-[#1E1E1E] rounded"
+            >
+              <option value="" disabled>
+                Select Role
+              </option>
+              {roles.map(r => (
+                <option key={r.id} value={r.id}>
+                  {r.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-4 py-2 bg-accent text-black rounded disabled:opacity-50"
+          >
+            {saving ? 'Saving...' : 'Create User'}
+          </button>
+        </form>
+      )}
+    </AuthGuard>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `/users/new` client page
- fetch roles on mount
- submit new user and redirect to `/users`
- wrap page with `AuthGuard`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c0969bce083328f85af9785fdf3bf