### PR TITLE
Add brand edit page

### DIFF
--- a/frontend/app/(main)/brands/[id]/edit/page.tsx
+++ b/frontend/app/(main)/brands/[id]/edit/page.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import AuthGuard from '../../../../../components/AuthGuard';
+import Spinner from '../../../../../components/Spinner';
+import api from '../../../../../lib/api';
+import { useAuth } from '../../../../../context/AuthContext';
+
+interface ApiBrand {
+  id: number;
+  name: string;
+}
+
+export default function BrandEditPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const { user } = useAuth();
+
+  const [name, setName] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  const permissions = user?.permissions?.map((p: any) => p.code) || [];
+  const canEdit = permissions.includes('brands:edit');
+
+  useEffect(() => {
+    setLoading(true);
+    api
+      .get<ApiBrand>(`/brands/${params.id}`)
+      .then(res => {
+        setName(res.data.name);
+        setError('');
+      })
+      .catch(() => setError('Failed to load brand'))
+      .finally(() => setLoading(false));
+  }, [params.id]);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError('');
+    try {
+      await api.put(`/brands/${params.id}`, { name });
+      router.push(`/brands/${params.id}`);
+    } catch (err) {
+      setError('Failed to save brand');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!canEdit) {
+    return (
+      <AuthGuard>
+        <p>You do not have permission to edit brands.</p>
+      </AuthGuard>
+    );
+  }
+
+  return (
+    <AuthGuard>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <form onSubmit={onSubmit} className="space-y-4 max-w-md">
+          {error && <p className="text-red-500">{error}</p>}
+          <div>
+            <label className="block mb-1">Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              className="w-full p-2 bg-[#1E1E1E] rounded"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-4 py-2 bg-accent text-black rounded disabled:opacity-50"
+          >
+            {saving ? 'Saving...' : 'Save Changes'}
+          </button>
+        </form>
+      )}
+    </AuthGuard>
+  );
+}


### PR DESCRIPTION
## Summary
- add client page for editing a brand name

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68814e04bf2c83328b7af4d9fc315752