### PR TITLE
Protect flavors view with permission check

### DIFF
--- a/frontend/app/(main)/flavors/page.tsx
+++ b/frontend/app/(main)/flavors/page.tsx
@@ -28,11 +28,17 @@ export default function FlavorsPage() {
   const [brandId, setBrandId] = useState<number | ''>('');
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    api.get<ApiBrand[]>('/brands').then(res => setBrands(res.data));
-  }, []);
+  const permissions = user?.permissions?.map((p: any) => p.code) || [];
+  const canView = permissions.includes('flavors:view');
+  const canCreate = permissions.includes('flavors:create');
 
   useEffect(() => {
+    if (!canView) return;
+    api.get<ApiBrand[]>('/brands').then(res => setBrands(res.data));
+  }, [canView]);
+
+  useEffect(() => {
+    if (!canView) return;
     setLoading(true);
     api
       .get<ApiFlavor[]>('/flavors', {
@@ -43,10 +49,15 @@ export default function FlavorsPage() {
       })
       .then(res => setFlavors(res.data))
       .finally(() => setLoading(false));
-  }, [search, brandId]);
+  }, [search, brandId, canView]);
 
-  const permissions = user?.permissions?.map((p: any) => p.code) || [];
-  const canCreate = permissions.includes('flavors:create');
+  if (!canView) {
+    return (
+      <AuthGuard>
+        <p>You do not have permission to view flavors.</p>
+      </AuthGuard>
+    );
+  }
 
   return (
     <AuthGuard>


### PR DESCRIPTION
## Summary
- protect `/flavors` page by verifying `flavors:view` permission
- only fetch flavors/brands when user has permission
- show message when access is denied

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6881e1593f8c8332910c8e00d89dfefa