### PR TITLE
Add flavor deletion

### DIFF
--- a/frontend/app/(main)/flavors/[id]/page.tsx
+++ b/frontend/app/(main)/flavors/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import AuthGuard from '../../../../components/AuthGuard';
 import Spinner from '../../../../components/Spinner';
@@ -18,6 +18,7 @@ interface ApiFlavor {
 
 export default function FlavorDetailsPage() {
   const params = useParams<{ id: string }>();
+  const router = useRouter();
   const { user } = useAuth();
   const [flavor, setFlavor] = useState<ApiFlavor | null>(null);
   const [loading, setLoading] = useState(true);
@@ -37,6 +38,7 @@ export default function FlavorDetailsPage() {
 
   const permissions = user?.permissions?.map((p: any) => p.code) || [];
   const canEdit = permissions.includes('flavors:edit');
+  const canDelete = permissions.includes('flavors:delete');
 
   return (
     <AuthGuard>
@@ -65,10 +67,36 @@ export default function FlavorDetailsPage() {
               </tbody>
             </table>
           </div>
-          {canEdit && (
-            <Link href={`/flavors/${flavor.id}/edit`} className="px-4 py-2 bg-accent text-black rounded">
-              Edit
-            </Link>
+          {(canEdit || canDelete) && (
+            <div className="space-x-2">
+              {canEdit && (
+                <Link
+                  href={`/flavors/${flavor.id}/edit`}
+                  className="px-4 py-2 bg-accent text-black rounded"
+                >
+                  Edit
+                </Link>
+              )}
+              {canDelete && (
+                <button
+                  onClick={async () => {
+                    if (
+                      window.confirm('Are you sure you want to delete this flavor?')
+                    ) {
+                      try {
+                        await api.delete(`/flavors/${flavor.id}`);
+                        router.push('/flavors');
+                      } catch (err) {
+                        alert('Failed to delete flavor');
+                      }
+                    }
+                  }}
+                  className="px-4 py-2 bg-red-600 text-white rounded"
+                >
+                  Delete
+                </button>
+              )}
+            </div>
           )}
         </div>
       ) : null}


### PR DESCRIPTION
## Summary
- enable deleting a flavor from the details page if the user has the `flavors:delete` permission

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68823d385b008332b2c9ca885651dd28