### PR TITLE
Add protected brand detail page with edit and delete

### DIFF
--- a/frontend/app/(main)/brands/[id]/page.tsx
+++ b/frontend/app/(main)/brands/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import AuthGuard from '../../../../components/AuthGuard';
 import Spinner from '../../../../components/Spinner';
@@ -11,28 +11,33 @@ import { useAuth } from '../../../../context/AuthContext';
 interface ApiFlavor {
   id: number;
   name: string;
+  description: string;
   profile?: string;
 }
 
 interface ApiBrand {
   id: number;
   name: string;
-  flavors: ApiFlavor[];
 }
 
 export default function BrandDetailsPage() {
   const params = useParams<{ id: string }>();
+  const router = useRouter();
   const { user } = useAuth();
   const [brand, setBrand] = useState<ApiBrand | null>(null);
+  const [flavors, setFlavors] = useState<ApiFlavor[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
   useEffect(() => {
     setLoading(true);
-    api
-      .get<ApiBrand>(`/brands/${params.id}`)
-      .then(res => {
-        setBrand(res.data);
+    Promise.all([
+      api.get<ApiBrand>(`/brands/${params.id}`),
+      api.get<ApiFlavor[]>('/flavors', { params: { brandId: params.id } }),
+    ])
+      .then(([brandRes, flavorRes]) => {
+        setBrand(brandRes.data);
+        setFlavors(flavorRes.data);
         setError('');
       })
       .catch(() => setError('Failed to load brand'))
@@ -41,6 +46,7 @@ export default function BrandDetailsPage() {
 
   const permissions = user?.permissions?.map((p: any) => p.code) || [];
   const canEdit = permissions.includes('brands:edit');
+  const canDelete = permissions.includes('brands:delete');
 
   return (
     <AuthGuard>
@@ -53,18 +59,20 @@ export default function BrandDetailsPage() {
           <div className="bg-[#1E1E1E] p-4 rounded">
             <h1 className="text-xl font-bold mb-4">{brand.name}</h1>
             <h2 className="text-lg font-semibold mb-2">Flavors</h2>
-            {brand.flavors.length > 0 ? (
+            {flavors.length > 0 ? (
               <table className="w-full text-sm">
                 <thead>
                   <tr>
                     <th className="p-2 text-left">Name</th>
+                    <th className="p-2 text-left">Description</th>
                     <th className="p-2 text-left">Profile</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {brand.flavors.map(f => (
+                  {flavors.map(f => (
                     <tr key={f.id} className="border-t border-gray-700">
                       <td className="p-2">{f.name}</td>
+                      <td className="p-2">{f.description || '-'}</td>
                       <td className="p-2">{f.profile || '-'}</td>
                     </tr>
                   ))}
@@ -74,10 +82,36 @@ export default function BrandDetailsPage() {
               <p>No flavors found</p>
             )}
           </div>
-          {canEdit && (
-            <Link href={`/brands/${brand.id}/edit`} className="px-4 py-2 bg-accent text-black rounded">
-              Edit
-            </Link>
+          {(canEdit || canDelete) && (
+            <div className="space-x-2">
+              {canEdit && (
+                <Link
+                  href={`/brands/${brand.id}/edit`}
+                  className="px-4 py-2 bg-accent text-black rounded"
+                >
+                  Edit
+                </Link>
+              )}
+              {canDelete && (
+                <button
+                  onClick={async () => {
+                    if (
+                      window.confirm('Are you sure you want to delete this brand?')
+                    ) {
+                      try {
+                        await api.delete(`/brands/${brand.id}`);
+                        router.push('/brands');
+                      } catch (err) {
+                        alert('Failed to delete brand');
+                      }
+                    }
+                  }}
+                  className="px-4 py-2 bg-red-600 text-white rounded"
+                >
+                  Delete
+                </button>
+              )}
+            </div>
           )}
         </div>
       ) : null}


### PR DESCRIPTION
## Summary
- extend the brand detail page to fetch brand and related flavors
- show flavors table with description and profile columns
- add Edit and Delete actions gated by permissions

## Testing
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_68823f1112a88332ba5c9bbdf6cf2b14