### PR TITLE
Implement editable user page with permissions

### DIFF
--- a/frontend/app/(main)/users/[id]/edit/page.tsx
+++ b/frontend/app/(main)/users/[id]/edit/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from 'next/navigation';
 import AuthGuard from '../../../../../components/AuthGuard';
 import Spinner from '../../../../../components/Spinner';
 import api from '../../../../../lib/api';
+import { useAuth } from '../../../../../context/AuthContext';
 
 interface ApiRole {
   id: number;
@@ -15,65 +16,82 @@ interface ApiUser {
   id: number;
   firstName: string;
   lastName: string;
-  username: string;
-  role: { id: number; name: string };
+  email: string;
+  roles: ApiRole[];
 }
 
 export default function UserEditPage() {
   const params = useParams<{ id: string }>();
   const router = useRouter();
+  const { user } = useAuth();
+
+  const permissions = user?.permissions?.map((p: any) => p.code) || [];
+  const canEdit = permissions.includes('users:edit');
 
   const [roles, setRoles] = useState<ApiRole[]>([]);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [email, setEmail] = useState('');
+  const [roleIds, setRoleIds] = useState<number[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
 
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [roleId, setRoleId] = useState<number | ''>('');
-
-  const fetchData = () => {
+  useEffect(() => {
+    if (!canEdit) return;
     setLoading(true);
     Promise.all([
       api.get<ApiUser>(`/users/${params.id}`),
-      api.get<ApiRole[]>(`/roles`),
+      api.get<ApiRole[]>('/roles'),
     ])
       .then(([userRes, rolesRes]) => {
-        const user = userRes.data;
-        setFirstName(user.firstName);
-        setLastName(user.lastName);
-        setEmail(user.username);
-        setRoleId(user.role.id);
+        const u = userRes.data;
+        setFirstName(u.firstName);
+        setLastName(u.lastName);
+        setEmail(u.email);
+        setRoleIds(u.roles.map(r => r.id));
         setRoles(rolesRes.data);
+        setError('');
       })
       .catch(() => setError('Failed to load data'))
       .finally(() => setLoading(false));
-  };
+  }, [params.id, canEdit]);
 
-  useEffect(fetchData, [params.id]);
+  const onRolesChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const values = Array.from(e.target.selectedOptions).map(o => Number(o.value));
+    setRoleIds(values);
+  };
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!firstName || !lastName || !email) {
+      setError('All fields are required');
+      return;
+    }
     setSaving(true);
     setError('');
     try {
-      const body: any = {
+      await api.patch(`/users/${params.id}`, {
         firstName,
         lastName,
-        username: email,
-        roleId: Number(roleId),
-      };
-      if (password) body.password = password;
-      await api.put(`/users/${params.id}`, body);
-      router.push('/users');
-    } catch (err) {
+        email,
+        roleIds,
+      });
+      router.push(`/users/${params.id}`);
+    } catch {
       setError('Failed to save user');
     } finally {
       setSaving(false);
     }
   };
+
+  if (!canEdit) {
+    return (
+      <AuthGuard>
+        <p>You do not have permission to edit users.</p>
+      </AuthGuard>
+    );
+  }
 
   return (
     <AuthGuard>
@@ -88,7 +106,8 @@ export default function UserEditPage() {
               type="text"
               value={firstName}
               onChange={e => setFirstName(e.target.value)}
-              className="w-full p-2 bg-[#1E1E1E] rounded"
+              required
+              className="w-full p-2 bg-[#1E1E1E] text-white rounded"
             />
           </div>
           <div>
@@ -97,7 +116,8 @@ export default function UserEditPage() {
               type="text"
               value={lastName}
               onChange={e => setLastName(e.target.value)}
-              className="w-full p-2 bg-[#1E1E1E] rounded"
+              required
+              className="w-full p-2 bg-[#1E1E1E] text-white rounded"
             />
           </div>
           <div>
@@ -106,29 +126,18 @@ export default function UserEditPage() {
               type="email"
               value={email}
               onChange={e => setEmail(e.target.value)}
-              className="w-full p-2 bg-[#1E1E1E] rounded"
+              required
+              className="w-full p-2 bg-[#1E1E1E] text-white rounded"
             />
           </div>
           <div>
-            <label className="block mb-1">Password</label>
-            <input
-              type="password"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              placeholder="Leave blank to keep current"
-              className="w-full p-2 bg-[#1E1E1E] rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">Role</label>
+            <label className="block mb-1">Roles</label>
             <select
-              value={roleId}
-              onChange={e => setRoleId(Number(e.target.value))}
-              className="w-full p-2 bg-[#1E1E1E] rounded"
+              multiple
+              value={roleIds.map(String)}
+              onChange={onRolesChange}
+              className="w-full p-2 bg-[#1E1E1E] text-white rounded"
             >
-              <option value="" disabled>
-                Select Role
-              </option>
               {roles.map(r => (
                 <option key={r.id} value={r.id}>
                   {r.name}


### PR DESCRIPTION
## Summary
- add permissions check to user edit page
- load user and roles on mount
- submit updates via PATCH `/users/:id`
- use multi-select roles and dark themed form

## Testing
- `npm run build` in `frontend`
- ❌ `npm run build` in `backend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68825997af1483329f9aebcec341e753