### PR TITLE
Improve dashboard mobile layout

### DIFF
--- a/frontend/app/(main)/dashboard/page.tsx
+++ b/frontend/app/(main)/dashboard/page.tsx
@@ -79,36 +79,38 @@ export default function DashboardPage() {
           </div>
           <div>
             <h2 className="text-xl font-bold mb-2">Latest Requests</h2>
-            <table className="w-full text-sm text-left bg-[#1E1E1E] rounded">
-              <thead>
-                <tr>
-                  <th className="p-2">ID</th>
-                  <th className="p-2">User</th>
-                  <th className="p-2">Status</th>
-                  <th className="p-2">Date</th>
-                </tr>
-              </thead>
-              <tbody>
-                {latestRequests.map(r => (
-                  <tr
-                    key={r.id}
-                    onClick={() => router.push(`/requests/${r.id}`)}
-                    className="border-t border-gray-700 cursor-pointer hover:bg-[#2A2A2A]"
-                  >
-                    <td className="p-2">{r.id}</td>
-                    <td className="p-2">
-                      {r.createdBy.firstName} {r.createdBy.lastName}
-                    </td>
-                    <td className="p-2">
-                      <StatusBadge status={r.status} />
-                    </td>
-                    <td className="p-2">
-                      {new Date(r.createdAt).toLocaleString()}
-                    </td>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm text-left bg-[#1E1E1E] rounded">
+                <thead>
+                  <tr>
+                    <th className="p-2">ID</th>
+                    <th className="p-2">User</th>
+                    <th className="p-2">Status</th>
+                    <th className="p-2">Date</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {latestRequests.map(r => (
+                    <tr
+                      key={r.id}
+                      onClick={() => router.push(`/requests/${r.id}`)}
+                      className="border-t border-gray-700 cursor-pointer hover:bg-[#2A2A2A]"
+                    >
+                      <td className="p-2">{r.id}</td>
+                      <td className="p-2">
+                        {r.createdBy.firstName} {r.createdBy.lastName}
+                      </td>
+                      <td className="p-2">
+                        <StatusBadge status={r.status} />
+                      </td>
+                      <td className="p-2">
+                        {new Date(r.createdAt).toLocaleString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
       )}

--- a/frontend/components/Card.tsx
+++ b/frontend/components/Card.tsx
@@ -5,7 +5,7 @@ interface CardProps {
 
 export default function Card({ title, value }: CardProps) {
   return (
-    <div className="bg-[#1E1E1E] p-4 rounded shadow text-center">
+    <div className="w-full p-4 bg-[#1E1E1E] rounded shadow text-center">
       <div className="text-sm text-gray-400">{title}</div>
       <div className="text-2xl font-semibold">{value}</div>
     </div>


### PR DESCRIPTION
## Summary
- make `Card` component full width so it stacks cleanly on small screens
- wrap latest requests table in a horizontally scrollable div

## Testing
- `npm run build` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_688266d45620833281c30511837418ab