### PR TITLE
Make brand edit page responsive

### DIFF
--- a/frontend/app/(main)/brands/[id]/edit/page.tsx
+++ b/frontend/app/(main)/brands/[id]/edit/page.tsx
@@ -64,25 +64,27 @@ export default function BrandEditPage() {
       {loading ? (
         <Spinner />
       ) : (
-        <form onSubmit={onSubmit} className="space-y-4 max-w-md">
-          {error && <p className="text-red-500">{error}</p>}
-          <div>
-            <label className="block mb-1">Name</label>
-            <input
-              type="text"
-              value={name}
-              onChange={e => setName(e.target.value)}
-              className="w-full p-2 bg-[#1E1E1E] rounded"
-            />
-          </div>
-          <button
-            type="submit"
-            disabled={saving}
-            className="px-4 py-2 bg-accent text-black rounded disabled:opacity-50"
-          >
-            {saving ? 'Saving...' : 'Save Changes'}
-          </button>
-        </form>
+        <div className="p-4 max-w-screen-sm mx-auto">
+          <form onSubmit={onSubmit} className="space-y-4">
+            {error && <p className="text-red-500">{error}</p>}
+            <div>
+              <label className="block mb-1">Name</label>
+              <input
+                type="text"
+                value={name}
+                onChange={e => setName(e.target.value)}
+                className="w-full p-2 bg-[#1E1E1E] rounded"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={saving}
+              className="w-full sm:w-auto px-4 py-2 bg-accent text-black rounded disabled:opacity-50 block mx-auto"
+            >
+              {saving ? 'Saving...' : 'Save Changes'}
+            </button>
+          </form>
+        </div>
       )}
     </AuthGuard>
   );


### PR DESCRIPTION
## Summary
- adjust brand edit page layout to match create page responsiveness
- include wrapper div with padding and centering
- make submit button responsive

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68827624bb0883328fbed7c768a93c5e