### PR TITLE
Make all admin pages mobile responsive

### DIFF
--- a/frontend/app/(main)/brands/[id]/page.tsx
+++ b/frontend/app/(main)/brands/[id]/page.tsx
@@ -91,24 +91,26 @@ export default function BrandDetailsPage() {
             </div>
             <h2 className="text-lg font-semibold mb-2">Flavors</h2>
             {flavors.length > 0 ? (
-              <table className="w-full text-sm">
-                <thead>
-                  <tr>
-                    <th className="p-2 text-left">Name</th>
-                    <th className="p-2 text-left">Description</th>
-                    <th className="p-2 text-left">Profile</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {flavors.map(f => (
-                    <tr key={f.id} className="border-t border-gray-700">
-                      <td className="p-2">{f.name}</td>
-                      <td className="p-2">{f.description || '-'}</td>
-                      <td className="p-2">{f.profile || '-'}</td>
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-sm">
+                  <thead>
+                    <tr>
+                      <th className="p-2 text-left">Name</th>
+                      <th className="p-2 text-left">Description</th>
+                      <th className="p-2 text-left">Profile</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody>
+                    {flavors.map(f => (
+                      <tr key={f.id} className="border-t border-gray-700 flex flex-col sm:table-row">
+                        <td className="p-2">{f.name}</td>
+                        <td className="p-2">{f.description || '-'}</td>
+                        <td className="p-2">{f.profile || '-'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             ) : (
               <p>No flavors found</p>
             )}

--- a/frontend/app/(main)/dashboard/page.tsx
+++ b/frontend/app/(main)/dashboard/page.tsx
@@ -70,7 +70,7 @@ export default function DashboardPage() {
       {loading ? (
         <Spinner />
       ) : (
-        <div className="space-y-6">
+        <div className="space-y-6 p-4 max-w-screen-xl mx-auto">
           <h1 className="text-2xl font-bold">Dashboard</h1>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
             <Card title="Requests" value={requestStats?.total ?? 0} />
@@ -80,7 +80,7 @@ export default function DashboardPage() {
           <div>
             <h2 className="text-xl font-bold mb-2">Latest Requests</h2>
             <div className="overflow-x-auto">
-              <table className="w-full text-sm text-left bg-[#1E1E1E] rounded">
+              <table className="min-w-full text-sm text-left bg-[#1E1E1E] rounded">
                 <thead>
                   <tr>
                     <th className="p-2">ID</th>
@@ -94,7 +94,7 @@ export default function DashboardPage() {
                     <tr
                       key={r.id}
                       onClick={() => router.push(`/requests/${r.id}`)}
-                      className="border-t border-gray-700 cursor-pointer hover:bg-[#2A2A2A]"
+                      className="border-t border-gray-700 cursor-pointer hover:bg-[#2A2A2A] flex flex-col sm:table-row"
                     >
                       <td className="p-2">{r.id}</td>
                       <td className="p-2">

--- a/frontend/app/(main)/flavors/[id]/edit/page.tsx
+++ b/frontend/app/(main)/flavors/[id]/edit/page.tsx
@@ -91,8 +91,9 @@ export default function FlavorEditPage() {
       {loading ? (
         <Spinner />
       ) : (
-        <form onSubmit={onSubmit} className="space-y-4 max-w-md">
-          {error && <p className="text-red-500">{error}</p>}
+        <div className="p-4 max-w-screen-sm mx-auto">
+          <form onSubmit={onSubmit} className="space-y-4">
+            {error && <p className="text-red-500">{error}</p>}
           <div>
             <label className="block mb-1">Name</label>
             <input
@@ -140,11 +141,12 @@ export default function FlavorEditPage() {
           <button
             type="submit"
             disabled={saving}
-            className="px-4 py-2 bg-accent text-black rounded disabled:opacity-50"
+            className="w-full sm:w-auto px-4 py-2 bg-accent text-black rounded disabled:opacity-50 block mx-auto"
           >
             {saving ? 'Saving...' : 'Save Changes'}
           </button>
-        </form>
+          </form>
+        </div>
       )}
     </AuthGuard>
   );

--- a/frontend/app/(main)/flavors/[id]/page.tsx
+++ b/frontend/app/(main)/flavors/[id]/page.tsx
@@ -47,32 +47,34 @@ export default function FlavorDetailsPage() {
       ) : error ? (
         <p className="text-red-500">{error}</p>
       ) : flavor ? (
-        <div className="space-y-4">
+        <div className="space-y-4 p-4 max-w-screen-sm mx-auto">
           <div className="bg-[#1E1E1E] p-4 rounded">
             <h1 className="text-xl font-bold mb-4">{flavor.name}</h1>
-            <table className="w-full text-sm">
-              <tbody>
-                <tr>
-                  <td className="p-2 font-semibold">Description</td>
-                  <td className="p-2">{flavor.description || '-'}</td>
-                </tr>
-                <tr>
-                  <td className="p-2 font-semibold">Profile</td>
-                  <td className="p-2">{flavor.profile || '-'}</td>
-                </tr>
-                <tr>
-                  <td className="p-2 font-semibold">Brand</td>
-                  <td className="p-2">{flavor.brand.name}</td>
-                </tr>
-              </tbody>
-            </table>
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <tbody>
+                  <tr className="flex flex-col sm:table-row">
+                    <td className="p-2 font-semibold">Description</td>
+                    <td className="p-2">{flavor.description || '-'}</td>
+                  </tr>
+                  <tr className="flex flex-col sm:table-row">
+                    <td className="p-2 font-semibold">Profile</td>
+                    <td className="p-2">{flavor.profile || '-'}</td>
+                  </tr>
+                  <tr className="flex flex-col sm:table-row">
+                    <td className="p-2 font-semibold">Brand</td>
+                    <td className="p-2">{flavor.brand.name}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
           {(canEdit || canDelete) && (
-            <div className="space-x-2">
+            <div className="space-y-2 sm:space-x-2 sm:space-y-0 flex flex-col sm:flex-row">
               {canEdit && (
                 <Link
                   href={`/flavors/${flavor.id}/edit`}
-                  className="px-4 py-2 bg-accent text-black rounded"
+                  className="w-full sm:w-auto px-4 py-2 bg-accent text-black rounded text-center"
                 >
                   Edit
                 </Link>
@@ -91,7 +93,7 @@ export default function FlavorDetailsPage() {
                       }
                     }
                   }}
-                  className="px-4 py-2 bg-red-600 text-white rounded"
+                  className="w-full sm:w-auto px-4 py-2 bg-red-600 text-white rounded"
                 >
                   Delete
                 </button>

--- a/frontend/app/(main)/flavors/new/page.tsx
+++ b/frontend/app/(main)/flavors/new/page.tsx
@@ -67,8 +67,9 @@ export default function FlavorCreatePage() {
       {loading ? (
         <Spinner />
       ) : (
-        <form onSubmit={onSubmit} className="space-y-4 max-w-md">
-          {error && <p className="text-red-500">{error}</p>}
+        <div className="p-4 max-w-screen-sm mx-auto">
+          <form onSubmit={onSubmit} className="space-y-4">
+            {error && <p className="text-red-500">{error}</p>}
           <div>
             <label className="block mb-1">Name</label>
             <input
@@ -115,11 +116,12 @@ export default function FlavorCreatePage() {
           <button
             type="submit"
             disabled={saving}
-            className="px-4 py-2 bg-accent text-black rounded disabled:opacity-50"
+            className="w-full sm:w-auto px-4 py-2 bg-accent text-black rounded disabled:opacity-50 block mx-auto"
           >
             {saving ? 'Saving...' : 'Create Flavor'}
           </button>
-        </form>
+          </form>
+        </div>
       )}
     </AuthGuard>
   );

--- a/frontend/app/(main)/flavors/page.tsx
+++ b/frontend/app/(main)/flavors/page.tsx
@@ -61,19 +61,19 @@ export default function FlavorsPage() {
 
   return (
     <AuthGuard>
-      <div className="space-y-4">
-        <div className="flex space-x-2 items-center">
+      <div className="space-y-4 p-4 max-w-screen-xl mx-auto">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:space-x-2 space-y-2 sm:space-y-0">
           <input
             type="text"
             placeholder="Search"
             value={search}
             onChange={e => setSearch(e.target.value)}
-            className="bg-[#1E1E1E] p-2 rounded w-64"
+            className="bg-[#1E1E1E] p-2 rounded w-full sm:w-64"
           />
           <select
             value={brandId}
             onChange={e => setBrandId(e.target.value ? Number(e.target.value) : '')}
-            className="bg-[#1E1E1E] p-2 rounded"
+            className="bg-[#1E1E1E] p-2 rounded w-full sm:w-auto"
           >
             <option value="">All Brands</option>
             {brands.map(b => (
@@ -83,7 +83,7 @@ export default function FlavorsPage() {
             ))}
           </select>
           {canCreate && (
-            <Link href="/flavors/new" className="ml-auto px-3 py-2 bg-accent text-black rounded">
+            <Link href="/flavors/new" className="w-full sm:w-auto sm:ml-auto px-3 py-2 bg-accent text-black rounded text-center">
               + Add Flavor
             </Link>
           )}
@@ -91,18 +91,19 @@ export default function FlavorsPage() {
         {loading ? (
           <Spinner />
         ) : (
-          <table className="w-full text-sm text-left bg-[#1E1E1E] rounded">
-            <thead>
-              <tr>
-                <th className="p-2">Name</th>
-                <th className="p-2">Profile</th>
-                <th className="p-2">Brand</th>
-                <th className="p-2">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm text-left bg-[#1E1E1E] rounded">
+              <thead>
+                <tr>
+                  <th className="p-2">Name</th>
+                  <th className="p-2">Profile</th>
+                  <th className="p-2">Brand</th>
+                  <th className="p-2">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
               {flavors.map(f => (
-                <tr key={f.id} className="border-t border-gray-700">
+                <tr key={f.id} className="border-t border-gray-700 flex flex-col sm:table-row">
                   <td className="p-2">{f.name}</td>
                   <td className="p-2">{f.profile || '-'}</td>
                   <td className="p-2">{f.brand.name}</td>
@@ -113,8 +114,9 @@ export default function FlavorsPage() {
                   </td>
                 </tr>
               ))}
-            </tbody>
-          </table>
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
     </AuthGuard>

--- a/frontend/app/(main)/layout.tsx
+++ b/frontend/app/(main)/layout.tsx
@@ -1,13 +1,15 @@
 'use client';
+import { useState } from 'react';
 import Sidebar from '../../components/Sidebar';
 import TopBar from '../../components/TopBar';
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   return (
     <div className="flex min-h-screen">
-      <Sidebar />
+      <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
       <div className="flex flex-col flex-1">
-        <TopBar />
+        <TopBar onMenuClick={() => setSidebarOpen(true)} />
         <main className="p-4 flex-1 overflow-y-auto">{children}</main>
       </div>
     </div>

--- a/frontend/app/(main)/permissions/page.tsx
+++ b/frontend/app/(main)/permissions/page.tsx
@@ -24,7 +24,7 @@ export default function PermissionsPage() {
 
   return (
     <AuthGuard>
-      <div className="space-y-4">
+      <div className="space-y-4 p-4 max-w-screen-md mx-auto">
         {loading ? <Spinner /> : <PermissionTable permissions={permissions} />}
       </div>
     </AuthGuard>

--- a/frontend/app/(main)/roles/[id]/page.tsx
+++ b/frontend/app/(main)/roles/[id]/page.tsx
@@ -71,10 +71,11 @@ export default function RoleEditPage() {
       {loading || !role ? (
         <Spinner />
       ) : (
-        <form onSubmit={onSubmit} className="space-y-4 max-w-md">
-          <div>
-            <label className="block mb-1">Name</label>
-            <input
+        <div className="p-4 max-w-screen-sm mx-auto">
+          <form onSubmit={onSubmit} className="space-y-4">
+            <div>
+              <label className="block mb-1">Name</label>
+              <input
               type="text"
               value={name}
               onChange={e => setName(e.target.value)}
@@ -99,11 +100,12 @@ export default function RoleEditPage() {
           <button
             type="submit"
             disabled={saving}
-            className="px-4 py-2 bg-accent text-black rounded disabled:opacity-50"
+            className="w-full sm:w-auto px-4 py-2 bg-accent text-black rounded disabled:opacity-50 block mx-auto"
           >
             {saving ? 'Saving...' : 'Save Changes'}
           </button>
-        </form>
+          </form>
+        </div>
       )}
     </AuthGuard>
   );

--- a/frontend/app/(main)/roles/new/page.tsx
+++ b/frontend/app/(main)/roles/new/page.tsx
@@ -53,8 +53,9 @@ export default function RoleCreatePage() {
       {loading ? (
         <Spinner />
       ) : (
-        <form onSubmit={onSubmit} className="space-y-4 max-w-md">
-          {error && <p className="text-red-500">{error}</p>}
+        <div className="p-4 max-w-screen-sm mx-auto">
+          <form onSubmit={onSubmit} className="space-y-4">
+            {error && <p className="text-red-500">{error}</p>}
           <div>
             <label className="block mb-1">Name</label>
             <input
@@ -82,11 +83,12 @@ export default function RoleCreatePage() {
           <button
             type="submit"
             disabled={saving}
-            className="px-4 py-2 bg-accent text-black rounded disabled:opacity-50"
+            className="w-full sm:w-auto px-4 py-2 bg-accent text-black rounded disabled:opacity-50 block mx-auto"
           >
             {saving ? 'Saving...' : 'Create Role'}
           </button>
-        </form>
+          </form>
+        </div>
       )}
     </AuthGuard>
   );

--- a/frontend/app/(main)/roles/page.tsx
+++ b/frontend/app/(main)/roles/page.tsx
@@ -24,7 +24,7 @@ export default function RolesPage() {
 
   return (
     <AuthGuard>
-      <div className="space-y-4">
+      <div className="space-y-4 p-4 max-w-screen-md mx-auto">
         {loading ? <Spinner /> : <RoleTable roles={roles} />}
       </div>
     </AuthGuard>

--- a/frontend/app/(main)/users/[id]/edit/page.tsx
+++ b/frontend/app/(main)/users/[id]/edit/page.tsx
@@ -98,8 +98,9 @@ export default function UserEditPage() {
       {loading ? (
         <Spinner />
       ) : (
-        <form onSubmit={onSubmit} className="space-y-4 max-w-md">
-          {error && <p className="text-red-500">{error}</p>}
+        <div className="p-4 max-w-screen-sm mx-auto">
+          <form onSubmit={onSubmit} className="space-y-4">
+            {error && <p className="text-red-500">{error}</p>}
           <div>
             <label className="block mb-1">First Name</label>
             <input
@@ -148,11 +149,12 @@ export default function UserEditPage() {
           <button
             type="submit"
             disabled={saving}
-            className="px-4 py-2 bg-accent text-black rounded disabled:opacity-50"
+            className="w-full sm:w-auto px-4 py-2 bg-accent text-black rounded disabled:opacity-50 block mx-auto"
           >
             {saving ? 'Saving...' : 'Save Changes'}
           </button>
-        </form>
+          </form>
+        </div>
       )}
     </AuthGuard>
   );

--- a/frontend/app/(main)/users/[id]/page.tsx
+++ b/frontend/app/(main)/users/[id]/page.tsx
@@ -56,42 +56,44 @@ export default function UserDetailsPage() {
       ) : error ? (
         <p className="text-red-500">{error}</p>
       ) : data ? (
-        <div className="space-y-4">
+        <div className="space-y-4 p-4 max-w-screen-sm mx-auto">
           <div className="bg-[#1E1E1E] p-4 rounded">
             <h1 className="text-xl font-bold mb-4">
               {data.firstName} {data.lastName}
             </h1>
-            <table className="w-full text-sm">
-              <tbody>
-                <tr>
-                  <td className="p-2 font-semibold">ID</td>
-                  <td className="p-2">{data.id}</td>
-                </tr>
-                <tr>
-                  <td className="p-2 font-semibold">First Name</td>
-                  <td className="p-2">{data.firstName}</td>
-                </tr>
-                <tr>
-                  <td className="p-2 font-semibold">Last Name</td>
-                  <td className="p-2">{data.lastName}</td>
-                </tr>
-                <tr>
-                  <td className="p-2 font-semibold">Email</td>
-                  <td className="p-2">{data.email}</td>
-                </tr>
-                <tr>
-                  <td className="p-2 font-semibold">Roles</td>
-                  <td className="p-2">{data.roles.map(r => r.name).join(', ')}</td>
-                </tr>
-                <tr>
-                  <td className="p-2 font-semibold">Created At</td>
-                  <td className="p-2">{data.createdAt ? new Date(data.createdAt).toLocaleString() : ''}</td>
-                </tr>
-              </tbody>
-            </table>
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <tbody>
+                  <tr className="flex flex-col sm:table-row">
+                    <td className="p-2 font-semibold">ID</td>
+                    <td className="p-2">{data.id}</td>
+                  </tr>
+                  <tr className="flex flex-col sm:table-row">
+                    <td className="p-2 font-semibold">First Name</td>
+                    <td className="p-2">{data.firstName}</td>
+                  </tr>
+                  <tr className="flex flex-col sm:table-row">
+                    <td className="p-2 font-semibold">Last Name</td>
+                    <td className="p-2">{data.lastName}</td>
+                  </tr>
+                  <tr className="flex flex-col sm:table-row">
+                    <td className="p-2 font-semibold">Email</td>
+                    <td className="p-2">{data.email}</td>
+                  </tr>
+                  <tr className="flex flex-col sm:table-row">
+                    <td className="p-2 font-semibold">Roles</td>
+                    <td className="p-2">{data.roles.map(r => r.name).join(', ')}</td>
+                  </tr>
+                  <tr className="flex flex-col sm:table-row">
+                    <td className="p-2 font-semibold">Created At</td>
+                    <td className="p-2">{data.createdAt ? new Date(data.createdAt).toLocaleString() : ''}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
           {canEdit && (
-            <Link href={`/users/${data.id}/edit`} className="px-4 py-2 bg-accent text-black rounded">
+            <Link href={`/users/${data.id}/edit`} className="w-full sm:w-auto px-4 py-2 bg-accent text-black rounded block text-center">
               Edit
             </Link>
           )}

--- a/frontend/app/(main)/users/new/page.tsx
+++ b/frontend/app/(main)/users/new/page.tsx
@@ -69,8 +69,9 @@ export default function UserCreatePage() {
       {loading ? (
         <Spinner />
       ) : (
-        <form onSubmit={onSubmit} className="space-y-4 max-w-md">
-          {error && <p className="text-red-500">{error}</p>}
+        <div className="p-4 max-w-screen-sm mx-auto">
+          <form onSubmit={onSubmit} className="space-y-4">
+            {error && <p className="text-red-500">{error}</p>}
           <div>
             <label className="block mb-1">First Name</label>
             <input
@@ -127,11 +128,12 @@ export default function UserCreatePage() {
           <button
             type="submit"
             disabled={saving}
-            className="px-4 py-2 bg-accent text-black rounded disabled:opacity-50"
+            className="w-full sm:w-auto px-4 py-2 bg-accent text-black rounded disabled:opacity-50 block mx-auto"
           >
             {saving ? 'Saving...' : 'Create User'}
           </button>
-        </form>
+          </form>
+        </div>
       )}
     </AuthGuard>
   );

--- a/frontend/app/(main)/users/page.tsx
+++ b/frontend/app/(main)/users/page.tsx
@@ -38,28 +38,32 @@ export default function UsersPage() {
       ) : loading ? (
         <Spinner />
       ) : (
-        <table className="w-full text-sm text-left bg-[#1E1E1E] text-white rounded">
-          <thead>
-            <tr>
-              <th className="p-2">ID</th>
-              <th className="p-2">First Name</th>
-              <th className="p-2">Last Name</th>
-              <th className="p-2">Email</th>
-              <th className="p-2">Roles</th>
-            </tr>
-          </thead>
-          <tbody>
-            {users.map(u => (
-              <tr key={u.id} className="border-t border-gray-700">
-                <td className="p-2">{u.id}</td>
-                <td className="p-2">{u.firstName}</td>
-                <td className="p-2">{u.lastName}</td>
-                <td className="p-2">{u.email}</td>
-                <td className="p-2">{u.roles.map(r => r.name).join(', ')}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <div className="p-4 max-w-screen-md mx-auto">
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm text-left bg-[#1E1E1E] text-white rounded">
+              <thead>
+                <tr>
+                  <th className="p-2">ID</th>
+                  <th className="p-2">First Name</th>
+                  <th className="p-2">Last Name</th>
+                  <th className="p-2">Email</th>
+                  <th className="p-2">Roles</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map(u => (
+                  <tr key={u.id} className="border-t border-gray-700 flex flex-col sm:table-row">
+                    <td className="p-2">{u.id}</td>
+                    <td className="p-2">{u.firstName}</td>
+                    <td className="p-2">{u.lastName}</td>
+                    <td className="p-2">{u.email}</td>
+                    <td className="p-2">{u.roles.map(r => r.name).join(', ')}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
       )}
     </AuthGuard>
   );

--- a/frontend/app/(main)/users/permissions/page.tsx
+++ b/frontend/app/(main)/users/permissions/page.tsx
@@ -48,33 +48,35 @@ export default function UserPermissionsPage() {
 
   return (
     <AuthGuard>
-      <div className="space-y-4">
+      <div className="space-y-4 p-4 max-w-screen-md mx-auto">
         {loading ? (
           <Spinner />
         ) : (
-          <table className="w-full text-sm text-left bg-[#1E1E1E] rounded">
-            <thead>
-              <tr>
-                <th className="p-2">Code</th>
-                <th className="p-2">Description</th>
-                <th className="p-2">Roles</th>
-              </tr>
-            </thead>
-            <tbody>
-              {permissions.map(p => (
-                <tr key={p.id} className="border-t border-gray-700">
-                  <td className="p-2">{p.code}</td>
-                  <td className="p-2">{p.description}</td>
-                  <td className="p-2">
-                    {roles
-                      .filter(r => r.permissions.some(per => per.code === p.code))
-                      .map(r => r.name)
-                      .join(', ')}
-                  </td>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm text-left bg-[#1E1E1E] rounded">
+              <thead>
+                <tr>
+                  <th className="p-2">Code</th>
+                  <th className="p-2">Description</th>
+                  <th className="p-2">Roles</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {permissions.map(p => (
+                  <tr key={p.id} className="border-t border-gray-700 flex flex-col sm:table-row">
+                    <td className="p-2">{p.code}</td>
+                    <td className="p-2">{p.description}</td>
+                    <td className="p-2">
+                      {roles
+                        .filter(r => r.permissions.some(per => per.code === p.code))
+                        .map(r => r.name)
+                        .join(', ')}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
     </AuthGuard>

--- a/frontend/components/PermissionTable.tsx
+++ b/frontend/components/PermissionTable.tsx
@@ -8,23 +8,25 @@ interface Permission {
 
 export default function PermissionTable({ permissions }: { permissions: Permission[] }) {
   return (
-    <table className="w-full text-sm text-left bg-[#1E1E1E] rounded">
-      <thead>
-        <tr>
-          <th className="p-2">ID</th>
-          <th className="p-2">Code</th>
-          <th className="p-2">Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        {permissions.map(p => (
-          <tr key={p.id} className="border-t border-gray-700">
-            <td className="p-2">{p.id}</td>
-            <td className="p-2">{p.code}</td>
-            <td className="p-2">{p.description}</td>
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm text-left bg-[#1E1E1E] rounded">
+        <thead>
+          <tr>
+            <th className="p-2">ID</th>
+            <th className="p-2">Code</th>
+            <th className="p-2">Description</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {permissions.map(p => (
+            <tr key={p.id} className="border-t border-gray-700 flex flex-col sm:table-row">
+              <td className="p-2">{p.id}</td>
+              <td className="p-2">{p.code}</td>
+              <td className="p-2">{p.description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/frontend/components/RoleTable.tsx
+++ b/frontend/components/RoleTable.tsx
@@ -9,29 +9,31 @@ interface Role {
 
 export default function RoleTable({ roles }: { roles: Role[] }) {
   return (
-    <table className="w-full text-sm text-left bg-[#1E1E1E] rounded">
-      <thead>
-        <tr>
-          <th className="p-2">ID</th>
-          <th className="p-2">Name</th>
-          <th className="p-2">Permissions</th>
-          <th className="p-2">Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        {roles.map(role => (
-          <tr key={role.id} className="border-t border-gray-700">
-            <td className="p-2">{role.id}</td>
-            <td className="p-2">{role.name}</td>
-            <td className="p-2">{role.permissions.map(p => p.code).join(', ')}</td>
-            <td className="p-2">
-              <Link href={`/roles/${role.id}`} className="px-2 py-1 bg-accent text-black rounded">
-                Edit
-              </Link>
-            </td>
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm text-left bg-[#1E1E1E] rounded">
+        <thead>
+          <tr>
+            <th className="p-2">ID</th>
+            <th className="p-2">Name</th>
+            <th className="p-2">Permissions</th>
+            <th className="p-2">Actions</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {roles.map(role => (
+            <tr key={role.id} className="border-t border-gray-700 flex flex-col sm:table-row">
+              <td className="p-2">{role.id}</td>
+              <td className="p-2">{role.name}</td>
+              <td className="p-2">{role.permissions.map(p => p.code).join(', ')}</td>
+              <td className="p-2">
+                <Link href={`/roles/${role.id}`} className="px-2 py-1 bg-accent text-black rounded">
+                  Edit
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -12,22 +12,43 @@ const items = [
   { href: '/audit-logs', label: 'Audit Logs' },
 ];
 
-export default function Sidebar() {
+interface SidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function Sidebar({ isOpen, onClose }: SidebarProps) {
   const pathname = usePathname();
   return (
-    <aside className="w-64 bg-[#1E1E1E] p-4 space-y-2 hidden md:block">
-      {items.map((item) => (
-        <Link
-          key={item.href}
-          href={item.href}
-          className={clsx(
-            'block px-3 py-2 rounded hover:bg-[#2A2A2A]',
-            pathname === item.href && 'bg-[#2A2A2A]'
-          )}
-        >
-          {item.label}
-        </Link>
-      ))}
-    </aside>
+    <>
+      <div
+        className={clsx(
+          'fixed inset-0 bg-black bg-opacity-50 z-40 md:hidden',
+          isOpen ? 'block' : 'hidden'
+        )}
+        onClick={onClose}
+      />
+      <aside
+        className={clsx(
+          'fixed inset-y-0 left-0 w-64 bg-[#1E1E1E] p-4 space-y-2 transform transition-transform z-50 md:static md:translate-x-0',
+          isOpen ? 'translate-x-0' : '-translate-x-full',
+          'md:block'
+        )}
+      >
+        {items.map(item => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={clsx(
+              'block px-3 py-2 rounded hover:bg-[#2A2A2A]',
+              pathname === item.href && 'bg-[#2A2A2A]'
+            )}
+            onClick={onClose}
+          >
+            {item.label}
+          </Link>
+        ))}
+      </aside>
+    </>
   );
 }

--- a/frontend/components/Table.tsx
+++ b/frontend/components/Table.tsx
@@ -16,31 +16,40 @@ interface TableProps {
 
 export default function Table({ requests, showDetails = false }: TableProps) {
   return (
-    <table className="w-full text-sm text-left bg-[#1E1E1E] rounded">
-      <thead>
-        <tr>
-          {showDetails && <th className="p-2">ID</th>}
-          <th className="p-2">Status</th>
-          {showDetails && <th className="p-2">Created At</th>}
-          <th className="p-2">User</th>
-          <th className="p-2">Comment</th>
-          <th className="p-2">Flavors</th>
-        </tr>
-      </thead>
-      <tbody>
-        {requests.map((r) => (
-          <tr key={r.id} className="border-t border-gray-700">
-            {showDetails && <td className="p-2">{r.id}</td>}
-            <td className="p-2"><StatusBadge status={r.status} /></td>
-            {showDetails && (
-              <td className="p-2">{r.createdAt ? new Date(r.createdAt).toLocaleString() : ''}</td>
-            )}
-            <td className="p-2">{r.user.name}</td>
-            <td className="p-2">{r.comment}</td>
-            <td className="p-2">{r.flavors.join(', ')}</td>
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm text-left bg-[#1E1E1E] rounded">
+        <thead>
+          <tr>
+            {showDetails && <th className="p-2">ID</th>}
+            <th className="p-2">Status</th>
+            {showDetails && <th className="p-2">Created At</th>}
+            <th className="p-2">User</th>
+            <th className="p-2">Comment</th>
+            <th className="p-2">Flavors</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {requests.map(r => (
+            <tr
+              key={r.id}
+              className="border-t border-gray-700 flex flex-col sm:table-row"
+            >
+              {showDetails && <td className="p-2">{r.id}</td>}
+              <td className="p-2">
+                <StatusBadge status={r.status} />
+              </td>
+              {showDetails && (
+                <td className="p-2">
+                  {r.createdAt ? new Date(r.createdAt).toLocaleString() : ''}
+                </td>
+              )}
+              <td className="p-2">{r.user.name}</td>
+              <td className="p-2">{r.comment}</td>
+              <td className="p-2">{r.flavors.join(', ')}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/frontend/components/TopBar.tsx
+++ b/frontend/components/TopBar.tsx
@@ -1,11 +1,24 @@
 'use client';
 import { useAuth } from '../context/AuthContext';
 
-export default function TopBar() {
+interface TopBarProps {
+  onMenuClick?: () => void;
+}
+
+export default function TopBar({ onMenuClick }: TopBarProps) {
   const { user, logout } = useAuth();
   return (
     <header className="bg-[#1E1E1E] h-12 flex items-center justify-between px-4">
-      <span>John Galt Panel</span>
+      <div className="flex items-center space-x-2">
+        <button
+          onClick={onMenuClick}
+          className="md:hidden focus:outline-none"
+          aria-label="Open menu"
+        >
+          &#9776;
+        </button>
+        <span>John Galt Panel</span>
+      </div>
       <div className="flex items-center space-x-4">
         {user && <span>{user.name}</span>}
         <button onClick={logout} className="text-red-400 hover:underline">

--- a/frontend/components/UserTable.tsx
+++ b/frontend/components/UserTable.tsx
@@ -11,27 +11,29 @@ interface User {
 
 export default function UserTable({ users }: { users: User[] }) {
   return (
-    <table className="w-full text-sm text-left bg-[#1E1E1E] rounded">
-      <thead>
-        <tr>
-          <th className="p-2">ID</th>
-          <th className="p-2">Full Name</th>
-          <th className="p-2">Email</th>
-          <th className="p-2">Role</th>
-          <th className="p-2">Created At</th>
-        </tr>
-      </thead>
-      <tbody>
-        {users.map(u => (
-          <tr key={u.id} className="border-t border-gray-700">
-            <td className="p-2">{u.id}</td>
-            <td className="p-2">{u.firstName} {u.lastName}</td>
-            <td className="p-2">{u.username}</td>
-            <td className="p-2">{u.role?.name}</td>
-            <td className="p-2">{u.createdAt ? new Date(u.createdAt).toLocaleString() : 'N/A'}</td>
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm text-left bg-[#1E1E1E] rounded">
+        <thead>
+          <tr>
+            <th className="p-2">ID</th>
+            <th className="p-2">Full Name</th>
+            <th className="p-2">Email</th>
+            <th className="p-2">Role</th>
+            <th className="p-2">Created At</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {users.map(u => (
+            <tr key={u.id} className="border-t border-gray-700 flex flex-col sm:table-row">
+              <td className="p-2">{u.id}</td>
+              <td className="p-2">{u.firstName} {u.lastName}</td>
+              <td className="p-2">{u.username}</td>
+              <td className="p-2">{u.role?.name}</td>
+              <td className="p-2">{u.createdAt ? new Date(u.createdAt).toLocaleString() : 'N/A'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add hamburger menu in `TopBar` and sliding `Sidebar`
- wrap tables with scroll containers and stack rows vertically on small screens
- ensure forms use responsive widths and centered padding
- update requests, brands, flavors, roles and users pages with mobile friendly layouts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688278342b9483329e5658e94b8e42af