### PR TITLE
Add filter and sort controls for requests

### DIFF
--- a/backend/src/requests/requests.controller.ts
+++ b/backend/src/requests/requests.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Post, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Post, Put, UseGuards, Query } from '@nestjs/common';
 import { RequestsService } from './requests.service';
 import { CreateRequestDto } from './dto/create-request.dto';
 import { UpdateRequestDto } from './dto/update-request.dto';
@@ -14,8 +14,16 @@ export class RequestsController {
   @Get()
   @UseGuards(AuthGuard, PermissionsGuard)
   @Permission('view_requests')
-  list() {
-    return this.requests.list();
+  list(
+    @Query('status') status?: string,
+    @Query('brandId') brandId?: string,
+    @Query('sort') sort?: string,
+  ) {
+    return this.requests.list(
+      status as any,
+      brandId ? Number(brandId) : undefined,
+      sort,
+    );
   }
 
   @Post()


### PR DESCRIPTION
## Summary
- allow query params for `/requests` endpoint
- filter/sort requests on the server side
- add brand/status/date/sort controls to requests page
- sync filters to URL

## Testing
- `npm run build` (frontend)
- `npm run build` *(fails: Missing script)* (backend)

------
https://chatgpt.com/codex/tasks/task_e_688288a272d48332968d8fdfcb7dac91