### PR TITLE
Add Nest build script and flavor filters

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "start": "node dist/main.js",
     "dev": "nest start --watch",
+    "build": "nest build",
     "seed:permissions": "ts-node src/seed/permissions.seed.ts",
     "seed:admin": "ts-node src/seed/admin.seed.ts"
   },

--- a/backend/src/flavors/flavors.controller.ts
+++ b/backend/src/flavors/flavors.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, UseGuards, Query } from '@nestjs/common';
 import { FlavorsService } from './flavors.service';
 import { CreateFlavorDto } from './dto/create-flavor.dto';
 import { UpdateFlavorDto } from './dto/update-flavor.dto';
@@ -12,8 +12,16 @@ export class FlavorsController {
   constructor(private flavors: FlavorsService) {}
 
   @Get()
-  list() {
-    return this.flavors.list();
+  list(
+    @Query('brandId') brandId?: string,
+    @Query('profile') profile?: string,
+    @Query('sort') sort?: string,
+  ) {
+    return this.flavors.list(
+      brandId ? Number(brandId) : undefined,
+      profile,
+      sort,
+    );
   }
 
   @Post()

--- a/backend/src/flavors/flavors.service.ts
+++ b/backend/src/flavors/flavors.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { CreateFlavorDto } from './dto/create-flavor.dto';
@@ -8,9 +9,19 @@ import { UpdateFlavorDto } from './dto/update-flavor.dto';
 export class FlavorsService {
   constructor(private prisma: PrismaService, private audit: AuditService) {}
 
-  list() {
+  list(brandId?: number, profile?: string, sort?: string) {
+    const where: Prisma.FlavorWhereInput = {};
+    if (brandId) where.brandId = brandId;
+    if (profile) where.profile = profile;
+
+    const orderBy: Prisma.FlavorOrderByWithRelationInput[] = [];
+    if (sort === 'name_asc') orderBy.push({ name: 'asc' });
+    if (sort === 'name_desc') orderBy.push({ name: 'desc' });
+
     return this.prisma.flavor.findMany({
+      where,
       include: { brand: { select: { name: true } } },
+      orderBy: orderBy.length > 0 ? orderBy : undefined,
     });
   }
 


### PR DESCRIPTION
## Summary
- add `nest build` backend script
- support filtering and sorting in `/flavors` endpoint
- update flavors page with brand, profile and sort dropdowns
- synchronize filter state with URL

## Testing
- `npm install` && `npm run build` in `backend`
- `npm install` && `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68828c6e96ec8332a2f0763d27dd7ee3