### PR TITLE
Add flavor forms with form validation

### DIFF
--- a/frontend/app/(main)/flavors/[id]/edit/page.tsx
+++ b/frontend/app/(main)/flavors/[id]/edit/page.tsx
@@ -2,6 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
 import AuthGuard from '../../../../../components/AuthGuard';
 import Spinner from '../../../../../components/Spinner';
 import api from '../../../../../lib/api';
@@ -20,6 +23,20 @@ interface ApiFlavor {
   brand: { id: number; name: string };
 }
 
+interface FormValues {
+  name: string;
+  description?: string | null;
+  profile?: string | null;
+  brandId: string;
+}
+
+const schema: yup.ObjectSchema<FormValues> = yup.object({
+  name: yup.string().required('Укажите название вкуса').min(2),
+  brandId: yup.string().required('Выберите бренд'),
+  profile: yup.string().nullable(),
+  description: yup.string().nullable(),
+});
+
 export default function FlavorEditPage() {
   const params = useParams<{ id: string }>();
   const router = useRouter();
@@ -27,16 +44,25 @@ export default function FlavorEditPage() {
 
   const [brands, setBrands] = useState<ApiBrand[]>([]);
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
 
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
-  const [profile, setProfile] = useState('');
-  const [brandId, setBrandId] = useState<number | ''>('');
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: yupResolver(schema),
+    defaultValues: {
+      name: '',
+      description: '',
+      profile: '',
+      brandId: '',
+    },
+  });
 
   const permissions = user?.permissions?.map((p: any) => p.code) || [];
-  const canEdit = permissions.includes('flavors:edit');
+  const canEdit = permissions.includes('flavors:update');
 
   const fetchData = () => {
     setLoading(true);
@@ -46,10 +72,10 @@ export default function FlavorEditPage() {
     ])
       .then(([flavorRes, brandsRes]) => {
         const f = flavorRes.data;
-        setName(f.name);
-        setDescription(f.description);
-        setProfile(f.profile);
-        setBrandId(f.brand.id);
+        setValue('name', f.name);
+        setValue('description', f.description || '');
+        setValue('profile', f.profile || '');
+        setValue('brandId', f.brand.id.toString());
         setBrands(brandsRes.data);
         setError('');
       })
@@ -59,22 +85,16 @@ export default function FlavorEditPage() {
 
   useEffect(fetchData, [params.id]);
 
-  const onSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSaving(true);
+  const onSubmit = async (data: FormValues) => {
     setError('');
     try {
-      await api.put(`/flavors/${params.id}`, {
-        name,
-        description,
-        profile,
-        brandId: Number(brandId),
+      await api.patch(`/flavors/${params.id}`, {
+        ...data,
+        brandId: Number(data.brandId),
       });
       router.push(`/flavors/${params.id}`);
     } catch (err) {
       setError('Не удалось сохранить вкус');
-    } finally {
-      setSaving(false);
     }
   };
 
@@ -92,59 +112,64 @@ export default function FlavorEditPage() {
         <Spinner />
       ) : (
         <div className="p-4 max-w-screen-sm mx-auto">
-          <form onSubmit={onSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
             {error && <p className="text-red-500">{error}</p>}
-          <div>
-            <label className="block mb-1">Название</label>
-            <input
-              type="text"
-              value={name}
-              onChange={e => setName(e.target.value)}
-              className="w-full p-2 bg-[#1E1E1E] rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">Описание</label>
-            <input
-              type="text"
-              value={description}
-              onChange={e => setDescription(e.target.value)}
-              className="w-full p-2 bg-[#1E1E1E] rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">Профиль</label>
-            <input
-              type="text"
-              value={profile}
-              onChange={e => setProfile(e.target.value)}
-              className="w-full p-2 bg-[#1E1E1E] rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">Бренд</label>
-            <select
-              value={brandId}
-              onChange={e => setBrandId(Number(e.target.value))}
-              className="w-full p-2 bg-[#1E1E1E] rounded"
-            >
-              <option value="" disabled>
-                Выберите бренд
-              </option>
-              {brands.map(b => (
-                <option key={b.id} value={b.id}>
-                  {b.name}
+            <div>
+              <label className="block mb-1">Название</label>
+              <input
+                type="text"
+                placeholder="Название вкуса"
+                {...register('name')}
+                className="w-full p-2 bg-[#1E1E1E] rounded"
+              />
+              {errors.name && (
+                <p className="text-red-500 text-sm">{errors.name.message}</p>
+              )}
+            </div>
+            <div>
+              <label className="block mb-1">Описание</label>
+              <input
+                type="text"
+                placeholder="Описание"
+                {...register('description')}
+                className="w-full p-2 bg-[#1E1E1E] rounded"
+              />
+            </div>
+            <div>
+              <label className="block mb-1">Профиль</label>
+              <input
+                type="text"
+                placeholder="Профиль"
+                {...register('profile')}
+                className="w-full p-2 bg-[#1E1E1E] rounded"
+              />
+            </div>
+            <div>
+              <label className="block mb-1">Бренд</label>
+              <select
+                {...register('brandId')}
+                className="w-full p-2 bg-[#1E1E1E] rounded"
+              >
+                <option value="" disabled>
+                  Выберите бренд
                 </option>
-              ))}
-            </select>
-          </div>
-          <button
-            type="submit"
-            disabled={saving}
-            className="w-full sm:w-auto px-4 py-2 bg-accent text-black rounded disabled:opacity-50 block mx-auto"
-          >
-            {saving ? 'Сохранение...' : 'Сохранить изменения'}
-          </button>
+                {brands.map(b => (
+                  <option key={b.id} value={b.id}>
+                    {b.name}
+                  </option>
+                ))}
+              </select>
+              {errors.brandId && (
+                <p className="text-red-500 text-sm">{errors.brandId.message}</p>
+              )}
+            </div>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full sm:w-auto px-4 py-2 bg-accent text-black rounded disabled:opacity-50 block mx-auto"
+            >
+              {isSubmitting ? 'Сохранение...' : 'Сохранить изменения'}
+            </button>
           </form>
         </div>
       )}

--- a/frontend/app/(main)/flavors/new/page.tsx
+++ b/frontend/app/(main)/flavors/new/page.tsx
@@ -2,6 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import * as yup from 'yup';
+import { yupResolver } from '@hookform/resolvers/yup';
 import AuthGuard from '../../../../components/AuthGuard';
 import Spinner from '../../../../components/Spinner';
 import api from '../../../../lib/api';
@@ -12,17 +15,35 @@ interface ApiBrand {
   name: string;
 }
 
+interface FormValues {
+  name: string;
+  description?: string | null;
+  profile?: string | null;
+  brandId: string;
+}
+
+const schema: yup.ObjectSchema<FormValues> = yup.object({
+  name: yup.string().required('Укажите название вкуса').min(2),
+  brandId: yup.string().required('Выберите бренд'),
+  profile: yup.string().nullable(),
+  description: yup.string().nullable(),
+});
+
 export default function FlavorCreatePage() {
   const router = useRouter();
   const { user } = useAuth();
   const [brands, setBrands] = useState<ApiBrand[]>([]);
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
-  const [profile, setProfile] = useState('');
-  const [brandId, setBrandId] = useState<number | ''>('');
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: yupResolver(schema),
+    defaultValues: { name: '', description: '', profile: '', brandId: '' },
+  });
 
   useEffect(() => {
     api
@@ -35,22 +56,16 @@ export default function FlavorCreatePage() {
   const permissions = user?.permissions?.map((p: any) => p.code) || [];
   const canCreate = permissions.includes('flavors:create');
 
-  const onSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSaving(true);
+  const onSubmit = async (data: FormValues) => {
     setError('');
     try {
       const res = await api.post('/flavors', {
-        name,
-        description,
-        profile,
-        brandId: Number(brandId),
+        ...data,
+        brandId: Number(data.brandId),
       });
       router.push(`/flavors/${res.data.id}`);
     } catch (err) {
       setError('Не удалось создать вкус');
-    } finally {
-      setSaving(false);
     }
   };
 
@@ -68,58 +83,68 @@ export default function FlavorCreatePage() {
         <Spinner />
       ) : (
         <div className="p-4 max-w-screen-sm mx-auto">
-          <form onSubmit={onSubmit} className="space-y-4">
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
             {error && <p className="text-red-500">{error}</p>}
-          <div>
-            <label className="block mb-1">Название</label>
-            <input
-              type="text"
-              value={name}
-              onChange={e => setName(e.target.value)}
-              className="w-full p-2 bg-[#1E1E1E] rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">Описание</label>
-            <textarea
-              value={description}
-              onChange={e => setDescription(e.target.value)}
-              className="w-full p-2 bg-[#1E1E1E] rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">Профиль</label>
-            <input
-              type="text"
-              value={profile}
-              onChange={e => setProfile(e.target.value)}
-              className="w-full p-2 bg-[#1E1E1E] rounded"
-            />
-          </div>
-          <div>
-            <label className="block mb-1">Бренд</label>
-            <select
-              value={brandId}
-              onChange={e => setBrandId(Number(e.target.value))}
-              className="w-full p-2 bg-[#1E1E1E] rounded"
-            >
-              <option value="" disabled>
-                Выберите бренд
-              </option>
-              {brands.map(b => (
-                <option key={b.id} value={b.id}>
-                  {b.name}
+            <div>
+              <label className="block mb-1">Название</label>
+              <input
+                type="text"
+                placeholder="Название вкуса"
+                {...register('name')}
+                className="w-full p-2 bg-[#1E1E1E] rounded"
+              />
+              {errors.name && (
+                <p className="text-red-500 text-sm">{errors.name.message}</p>
+              )}
+            </div>
+            <div>
+              <label className="block mb-1">Описание</label>
+              <textarea
+                placeholder="Описание"
+                {...register('description')}
+                className="w-full p-2 bg-[#1E1E1E] rounded"
+              />
+              {errors.description && (
+                <p className="text-red-500 text-sm">
+                  {errors.description.message}
+                </p>
+              )}
+            </div>
+            <div>
+              <label className="block mb-1">Профиль</label>
+              <input
+                type="text"
+                placeholder="Профиль"
+                {...register('profile')}
+                className="w-full p-2 bg-[#1E1E1E] rounded"
+              />
+            </div>
+            <div>
+              <label className="block mb-1">Бренд</label>
+              <select
+                {...register('brandId')}
+                className="w-full p-2 bg-[#1E1E1E] rounded"
+              >
+                <option value="" disabled>
+                  Выберите бренд
                 </option>
-              ))}
-            </select>
-          </div>
-          <button
-            type="submit"
-            disabled={saving}
-            className="w-full sm:w-auto px-4 py-2 bg-accent text-black rounded disabled:opacity-50 block mx-auto"
-          >
-            {saving ? 'Сохранение...' : 'Создать вкус'}
-          </button>
+                {brands.map(b => (
+                  <option key={b.id} value={b.id}>
+                    {b.name}
+                  </option>
+                ))}
+              </select>
+              {errors.brandId && (
+                <p className="text-red-500 text-sm">{errors.brandId.message}</p>
+              )}
+            </div>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full sm:w-auto px-4 py-2 bg-accent text-black rounded disabled:opacity-50 block mx-auto"
+            >
+              {isSubmitting ? 'Сохранение...' : 'Создать вкус'}
+            </button>
           </form>
         </div>
       )}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,13 +7,16 @@
     "start": "next start"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.1.1",
     "axios": "^1.10.0",
     "clsx": "^2.1.1",
     "next": "14.1.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.61.1",
     "react-hot-toast": "^2.5.2",
-    "tailwindcss": "^3.4.0"
+    "tailwindcss": "^3.4.0",
+    "yup": "^1.6.1"
   },
   "devDependencies": {
     "@types/node": "24.0.15",


### PR DESCRIPTION
## Summary
- use `react-hook-form` and `yup` for flavor forms
- support creating new flavors with validation and permissions
- support editing flavors with validation and permissions
- add resolver packages to dependencies

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68829cf40b888332a323bb4109c9284e