### PR TITLE
Add dashboard statistics and charts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.61.1",
     "react-hot-toast": "^2.5.2",
+    "recharts": "^3.1.0",
     "tailwindcss": "^3.4.0",
     "yup": "^1.6.1"
   },


### PR DESCRIPTION
## Summary
- add Recharts dependency
- implement dashboard page with summary stats and charts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882a0b91bdc8332b1712f17ab54ada9