### PR TITLE
Add Jest and Cypress testing setup

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: './src',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: { '^.+\\.(t|j)s$': 'ts-jest' },
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
     "dev": "nest start --watch",
     "build": "nest build",
     "seed:permissions": "ts-node src/seed/permissions.seed.ts",
-    "seed:admin": "ts-node src/seed/admin.seed.ts"
+    "seed:admin": "ts-node src/seed/admin.seed.ts",
+    "test": "jest"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
@@ -17,17 +18,20 @@
     "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "csv-parse": "^5.5.0",
+    "multer": "^1.4.5-lts.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^5.0.0",
     "rxjs": "^7.8.1",
-    "multer": "^1.4.5-lts.1",
-    "csv-parse": "^5.5.0",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",
+    "@types/jest": "^30.0.0",
+    "jest": "^30.0.5",
     "prisma": "^6.12.0",
-    "typescript": "^5.2.0",
-    "ts-node": "^10.9.1"
+    "ts-jest": "^29.4.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.0"
   }
 }

--- a/backend/src/requests/requests.service.spec.ts
+++ b/backend/src/requests/requests.service.spec.ts
@@ -1,0 +1,83 @@
+import { RequestsService } from './requests.service';
+import { PrismaService } from '../prisma.service';
+import { AuditService } from '../audit/audit.service';
+
+// Simple in-memory mocks
+const prismaMock = () => ({
+  request: {
+    findMany: jest.fn(),
+    create: jest.fn(),
+    findUnique: jest.fn(),
+  },
+  requestFlavor: {
+    createMany: jest.fn(),
+  },
+});
+
+describe('RequestsService', () => {
+  let service: RequestsService;
+  let prisma: ReturnType<typeof prismaMock>;
+  let audit: { log: jest.Mock };
+
+  beforeEach(() => {
+    prisma = prismaMock() as any;
+    audit = { log: jest.fn() } as any;
+    service = new RequestsService(prisma as unknown as PrismaService, audit as unknown as AuditService);
+  });
+
+  it('findAll returns list of requests', async () => {
+    const now = new Date();
+    const requests = [
+      {
+        id: 1,
+        status: 'NEW',
+        comment: 'hello',
+        createdAt: now,
+        createdBy: { id: 2, firstName: 'John', lastName: 'Doe' },
+        flavors: [ { flavor: { id: 3, name: 'Vanilla', brandId: 1 } } ],
+      },
+    ];
+    (prisma.request.findMany as jest.Mock).mockResolvedValue(requests);
+
+    const result = await service.list();
+
+    expect(prisma.request.findMany).toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        id: 1,
+        status: 'NEW',
+        comment: 'hello',
+        createdAt: now,
+        createdBy: { id: 2, firstName: 'John', lastName: 'Doe' },
+        flavors: [{ id: 3, name: 'Vanilla', brandId: 1 }],
+      },
+    ]);
+  });
+
+  it('create creates a new request', async () => {
+    const dto: any = { comment: 'Need', flavorIds: [5, 6] };
+    const request = { id: 10 };
+    (prisma.request.create as jest.Mock).mockResolvedValue(request);
+    (prisma.request.findUnique as jest.Mock).mockResolvedValue({ id: 10 });
+
+    await service.create(dto, 7);
+
+    expect(prisma.request.create).toHaveBeenCalledWith({
+      data: { comment: dto.comment, createdById: 7 },
+    });
+    expect(prisma.requestFlavor.createMany).toHaveBeenCalledWith({
+      data: [
+        { requestId: 10, flavorId: 5 },
+        { requestId: 10, flavorId: 6 },
+      ],
+    });
+    expect(audit.log).toHaveBeenCalledWith('Request', 10, 'CREATE', 7, dto);
+    expect(prisma.request.findUnique).toHaveBeenCalledWith({
+      where: { id: 10 },
+      include: {
+        createdBy: { select: { id: true, firstName: true, lastName: true } },
+        flavors: { include: { flavor: { select: { id: true, name: true } } } },
+      },
+    });
+  });
+});

--- a/frontend/cypress/e2e/smoke.cy.ts
+++ b/frontend/cypress/e2e/smoke.cy.ts
@@ -1,0 +1,7 @@
+describe('Smoke Test', () => {
+  it('should load flavors page and display table', () => {
+    cy.visit('/flavors');
+    cy.contains('Название');
+    cy.get('table').should('exist');
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "cypress": "cypress open"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",
@@ -23,6 +24,7 @@
     "@types/node": "24.0.15",
     "@types/react": "19.1.8",
     "autoprefixer": "^10.4.14",
+    "cypress": "^14.5.2",
     "postcss": "^8.4.21",
     "typescript": "5.8.3"
   }


### PR DESCRIPTION
## Summary
- install Jest & add config for Nest backend
- write unit tests for RequestsService
- add Cypress with a simple smoke test

## Testing
- `npm test` in `backend`
- `npx cypress run` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_6882a27e16f4833280f22638e9f3cc79